### PR TITLE
feat: support changes for native-testing-library preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
 ## Table of Contents
 
 - [The problem](#the-problem)
@@ -40,10 +41,10 @@
   - [`toBeDisabled`](#tobedisabled)
   - [`toBeEnabled`](#tobeenabled)
   - [`toBeEmpty`](#tobeempty)
-  - [`toContainElement(element)`](#tocontainelementelement)
-  - [`toHaveProp(prop, value)`](#tohavepropprop-value)
-  - [`toHaveTextContent(text)`](#tohavetextcontenttext)
-  - [`toHaveStyle(styles)`](#tohavestylestyles)
+  - [`toContainElement`](#tocontainelementelement)
+  - [`toHaveProp`](#tohavepropprop-value)
+  - [`toHaveTextContent`](#tohavetextcontenttext)
+  - [`toHaveStyle`](#tohavestylestyles)
 - [Inspiration](#inspiration)
 - [Other solutions](#other-solutions)
 - [Contributors](#contributors)
@@ -162,10 +163,10 @@ const { getByTestId } = render(<View testID="empty" />);
 expect(getByTestId('empty')).toBeEmpty();
 ```
 
-### `toContainElement(element)`
+### `toContainElement`
 
-```javascript
-toContainElement();
+```typescript
+toContainElement(element: ReactTestInstance | null);
 ```
 
 Check if an element contains another element as a descendant. Again, will only work for native
@@ -195,10 +196,10 @@ expect(parent).toContainElement(child);
 expect(parent).not.toContainElement(grandparent);
 ```
 
-### `toHaveProp(prop, value)`
+### `toHaveProp`
 
-```javascript
-toHaveProp(prop, value);
+```typescript
+toHaveProp(prop: string, value?: any);
 ```
 
 Check that an element has a given prop. Only works for native elements, so this is similar to
@@ -224,10 +225,10 @@ expect(queryByTestId('button')).not.toHaveProp('disabled');
 expect(queryByTestId('button')).not.toHaveProp('title', 'ok');
 ```
 
-### `toHaveTextContent(text)`
+### `toHaveTextContent`
 
-```javascript
-toHaveTextContent(text);
+```typescript
+toHaveTextContent(text: string | RegExp, options?: { normalizeWhitespace: boolean });
 ```
 
 Check if an element has the supplied text.
@@ -248,10 +249,10 @@ expect(queryByTestId('count-value')).toHaveTextContent(/2/);
 expect(queryByTestId('count-value')).not.toHaveTextContent('21');
 ```
 
-### `toHaveStyle(styles)`
+### `toHaveStyle`
 
 ```javascript
-toHaveStyle(styles);
+toHaveStyle(style: object[] | object);
 ```
 
 Check if an element has the supplied styles.

--- a/extend-expect.d.ts
+++ b/extend-expect.d.ts
@@ -1,0 +1,13 @@
+import { ReactTestInstance } from 'react-test-renderer';
+
+declare namespace jest {
+  interface Matchers<R> {
+    toBeDisabled(): R;
+    toContainElement(element: ReactTestInstance | null): R;
+    toBeEmpty(): R;
+    toHaveProp(attr: string, value?: any): R;
+    toHaveTextContent(text: string | RegExp, options?: { normalizeWhitespace: boolean }): R;
+    toBeEnabled(): R;
+    toHaveStyle(style: object[] | object): R;
+  }
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,7 @@
 const ignores = ['/node_modules/', '/__tests__/helpers/', '__mocks__'];
 
 module.exports = {
-  preset: 'react-native',
-  transformIgnorePatterns: ['node_modules/(?!(react-native.*|@?react-navigation.*)/)'],
+  preset: 'native-testing-library',
   setupFilesAfterEnv: ['<rootDir>/setup-tests.js'],
   collectCoverageFrom: ['src/**/*.+(js|jsx|ts|tsx)'],
   testMatch: ['**/__tests__/**/*.+(js|jsx|ts|tsx)'],

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "files": [
     "dist",
-    "extend-expect.js"
+    "extend-expect.js",
+    "extend-expect.d.ts"
   ],
   "keywords": [
     "testing",
@@ -31,6 +32,7 @@
     "jest-matcher-utils": "^24.0.0",
     "ramda": "^0.26.1",
     "pretty-format": "^24.0.0",
+    "react-test-renderer": "^16.8.0",
     "redent": "^2.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "husky": "^1.3.1",
     "jest": "^24.7.1",
     "metro-react-native-babel-preset": "^0.52.0",
-    "native-testing-library": "1.x",
+    "native-testing-library": "^3.0.0-beta.1",
     "prettier": "^1.16.4",
     "pretty-quick": "^1.10.0",
     "react": "16.8.3",
@@ -50,9 +50,8 @@
     "semantic-release": "^15.13.3"
   },
   "peerDependencies": {
-    "native-testing-library": ">=1.2.0",
     "react": "*",
-    "react-native": "*"
+    "react-native": ">0.55"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "commit:all": "npm run commit:add && npm run commit",
     "readme:toc": "doctoc README.md --maxlevel 3 --title '## Table of Contents'",
     "test": "jest",
-    "pretty-quick": "pretty-quick --staged --pattern '**/*.(js|jsx|ts|tsx)'",
+    "pretty-quick": "pretty-quick --staged",
     "prepublishOnly": "rm -rf dist; babel src --out-dir dist --ignore 'src/__tests__/*'",
     "semantic-release": "semantic-release",
     "test:coverage": "jest --coverage",

--- a/setup-tests.js
+++ b/setup-tests.js
@@ -1,4 +1,5 @@
 import { plugins } from 'pretty-format';
+
 import './src/extend-expect';
 
 expect.addSnapshotSerializer(plugins.ConvertAnsi);

--- a/src/__tests__/to-be-disabled.js
+++ b/src/__tests__/to-be-disabled.js
@@ -10,7 +10,7 @@ import {
 import { render } from 'native-testing-library';
 
 test('.toBeDisabled', () => {
-  const { queryByTestId, queryByText } = render(
+  const { queryByTestId, queryByText, queryByTitle } = render(
     <View disabled testID="view">
       <Button disabled testID="button" title="button" />
       <TouchableHighlight disabled testID="highlight">
@@ -28,10 +28,8 @@ test('.toBeDisabled', () => {
   expect(queryByTestId('view')).toBeDisabled();
   expect(() => expect(queryByTestId('view')).not.toBeDisabled()).toThrowError();
 
-  expect(queryByTestId('button')).toBeDisabled();
-  expect(queryByText('button')).toBeDisabled();
-  expect(() => expect(queryByTestId('button')).not.toBeDisabled()).toThrowError();
-  expect(() => expect(queryByText('button')).not.toBeDisabled()).toThrowError();
+  expect(queryByTitle('button')).toBeDisabled();
+  expect(() => expect(queryByTitle('button')).not.toBeDisabled()).toThrowError();
 
   expect(queryByTestId('highlight')).toBeDisabled();
   expect(queryByText('highlight')).toBeDisabled();
@@ -50,9 +48,9 @@ test('.toBeDisabled', () => {
 });
 
 test('.toBeEnabled', () => {
-  const { queryByTestId, queryByText } = render(
+  const { queryByTestId, queryByText, queryByTitle } = render(
     <View testID="view">
-      <Button testID="button" title="button" />
+      <Button title="button" />
       <TouchableHighlight testID="highlight">
         <Text>highlight</Text>
       </TouchableHighlight>
@@ -68,10 +66,8 @@ test('.toBeEnabled', () => {
   expect(queryByTestId('view')).toBeEnabled();
   expect(() => expect(queryByTestId('view')).not.toBeEnabled()).toThrowError();
 
-  expect(queryByTestId('button')).toBeEnabled();
-  expect(queryByText('button')).toBeEnabled();
-  expect(() => expect(queryByTestId('button')).not.toBeEnabled()).toThrowError();
-  expect(() => expect(queryByText('button')).not.toBeEnabled()).toThrowError();
+  expect(queryByTitle('button')).toBeEnabled();
+  expect(() => expect(queryByTitle('button')).not.toBeEnabled()).toThrowError();
 
   expect(queryByTestId('highlight')).toBeEnabled();
   expect(queryByText('highlight')).toBeEnabled();
@@ -90,7 +86,7 @@ test('.toBeEnabled', () => {
 });
 
 test('matcher misses', () => {
-  const { queryByTestId, queryByText } = render(
+  const { queryByTestId, queryByTitle } = render(
     <View testID="view">
       <Button testID="enabled" title="enabled" />
       <Button disabled testID="disabled" title="disabled" />
@@ -98,5 +94,5 @@ test('matcher misses', () => {
   );
 
   expect(() => expect(queryByTestId('enabled')).toBeDisabled()).toThrowError();
-  expect(() => expect(queryByText('disabled')).toBeEnabled()).toThrowError();
+  expect(() => expect(queryByTitle('disabled')).toBeEnabled()).toThrowError();
 });

--- a/src/__tests__/to-have-prop.js
+++ b/src/__tests__/to-have-prop.js
@@ -3,7 +3,7 @@ import { Button, Text, View } from 'react-native';
 import { render } from 'native-testing-library';
 
 test('.toHaveProp', () => {
-  const { debug, queryByTestId } = render(
+  const { queryByTestId } = render(
     <View>
       <Text allowFontScaling={false} testID="text">
         text
@@ -12,20 +12,19 @@ test('.toHaveProp', () => {
     </View>,
   );
 
-  expect(queryByTestId('button')).toHaveProp('accessibilityStates', ['disabled']);
-  expect(queryByTestId('button')).toHaveProp('accessible');
-  expect(queryByTestId('button')).not.toHaveProp('disabled');
-  expect(queryByTestId('button')).not.toHaveProp('title', 'ok');
+  expect(queryByTestId('button')).toHaveProp('disabled', true);
+  expect(queryByTestId('button')).toHaveProp('disabled');
+  expect(queryByTestId('button')).toHaveProp('title', 'ok');
 
   expect(queryByTestId('text')).toHaveProp('allowFontScaling', false);
   expect(queryByTestId('text')).not.toHaveProp('style');
 
   expect(() =>
-    expect(queryByTestId('button')).not.toHaveProp('accessibilityStates', ['disabled']),
+    expect(queryByTestId('button')).toHaveProp('accessibilityStates', ['disabled']),
   ).toThrowError();
-  expect(() => expect(queryByTestId('button')).not.toHaveProp('accessible')).toThrowError();
-  expect(() => expect(queryByTestId('button')).toHaveProp('disabled')).toThrowError();
-  expect(() => expect(queryByTestId('button')).toHaveProp('title', 'ok')).toThrowError();
+  expect(() => expect(queryByTestId('button')).toHaveProp('accessible')).toThrowError();
+  expect(() => expect(queryByTestId('button')).not.toHaveProp('disabled')).toThrowError();
+  expect(() => expect(queryByTestId('button')).not.toHaveProp('title', 'ok')).toThrowError();
 
   expect(() =>
     expect(queryByTestId('text')).not.toHaveProp('allowFontScaling', false),

--- a/src/to-be-disabled.js
+++ b/src/to-be-disabled.js
@@ -5,6 +5,7 @@ import { checkReactElement, getType, printElement } from './utils';
 
 // Elements that support 'disabled'
 const DISABLE_TYPES = [
+  'Button',
   'Slider',
   'Switch',
   'Text',


### PR DESCRIPTION
<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

A jest preset meant to supercharge `native-testing-library`

**Why**:

<!-- Why are these changes necessary? -->

I want the same "DOM" feel in `debug` output and snapshots as `dom-testing-library` gives you. I think the RN core team already has a good idea of the type of mocks they want in the bundled jest preset, so for now we'll create our own to emulate the feel we want.

Ultimately, I could totally see these mocks merging back into `react-native`, and _I hope it does_ but until then, I'd like to be able to use this functionality as soon as possible. If for no other reason than the delay of merged features in RN, I think this is necessary to get moving,

**How**:

<!-- How were these changes implemented? -->

This requires unmocking some things from the `react-native` preset and doing it ourself.

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the [docs site](https://github.com/bcarroll22/native-testing-library-docs)
- [ ] Typescript definitions updated
- [ ] Tests
- [ ] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
