### PR TITLE
Merge extended matchers with the global namespace

### DIFF
--- a/extend-expect.d.ts
+++ b/extend-expect.d.ts
@@ -1,13 +1,15 @@
 import { ReactTestInstance } from 'react-test-renderer';
 
-declare namespace jest {
-  interface Matchers<R> {
-    toBeDisabled(): R;
-    toContainElement(element: ReactTestInstance | null): R;
-    toBeEmpty(): R;
-    toHaveProp(attr: string, value?: any): R;
-    toHaveTextContent(text: string | RegExp, options?: { normalizeWhitespace: boolean }): R;
-    toBeEnabled(): R;
-    toHaveStyle(style: object[] | object): R;
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toBeDisabled(): R;
+      toContainElement(element: ReactTestInstance | null): R;
+      toBeEmpty(): R;
+      toHaveProp(attr: string, value?: any): R;
+      toHaveTextContent(text: string | RegExp, options?: { normalizeWhitespace: boolean }): R;
+      toBeEnabled(): R;
+      toHaveStyle(style: object[] | object): R;
+    }
   }
 }


### PR DESCRIPTION
<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**:

Fixes TypeScript failing to find extended expect methods
Closes #7 

**How**:

By default a `d.ts` file augments the global namespace. As soon as an `import` or `export` is used in the `d.ts` file it changes to a module definition. This makes it necessary to use `declare global {}` to add to the global namespace explicitly. In `jest-dom/extend-expect.d.ts` which the current implementation is based on there are no imports which, I believe, is why it works fine.

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs](https://github.com/testing-library/jest-native/README.md) (N/A)
- [x] Typescript definitions updated
- [ ] Tests (N/A)
- [x] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
