### PR TITLE
Support nested arrays in style prop

### DIFF
--- a/src/__tests__/to-have-style.js
+++ b/src/__tests__/to-have-style.js
@@ -8,7 +8,7 @@ describe('.toHaveStyle', () => {
     const { getByTestId } = render(
       <View
         testID="container"
-        style={[{ backgroundColor: 'blue', height: '100%' }, styles.container]}
+        style={[{ backgroundColor: 'blue', height: '100%' }, [{ width: '50%' }], styles.container]}
       >
         <Text>Hello World</Text>
       </View>,
@@ -21,6 +21,7 @@ describe('.toHaveStyle', () => {
     expect(container).toHaveStyle({ backgroundColor: 'blue' });
     expect(container).toHaveStyle({ height: '100%' });
     expect(container).toHaveStyle({ color: 'white' });
+    expect(container).toHaveStyle({ width: '50%' });
   });
 
   test('handles negative test cases', () => {

--- a/src/to-have-style.js
+++ b/src/to-have-style.js
@@ -1,7 +1,7 @@
 import { matcherHint } from 'jest-matcher-utils';
 import jestDiff from 'jest-diff';
 import chalk from 'chalk';
-import { all, compose, mergeAll, toPairs } from 'ramda';
+import { all, compose, flatten, mergeAll, toPairs } from 'ramda';
 
 import { checkReactElement } from './utils';
 
@@ -10,6 +10,10 @@ function isSubset(expected, received) {
     all(([prop, value]) => received[prop] === value),
     toPairs,
   )(expected);
+}
+
+function mergeAllStyles(styles) {
+  return compose(mergeAll, flatten)(styles);
 }
 
 function printoutStyles(styles) {
@@ -36,8 +40,8 @@ export function toHaveStyle(element, style) {
 
   const elementStyle = element.props.style;
 
-  const expected = Array.isArray(style) ? mergeAll(style) : style;
-  const received = Array.isArray(elementStyle) ? mergeAll(elementStyle) : elementStyle;
+  const expected = Array.isArray(style) ? mergeAllStyles(style) : style;
+  const received = Array.isArray(elementStyle) ? mergeAllStyles(elementStyle) : elementStyle;
 
   return {
     pass: isSubset(expected, received),


### PR DESCRIPTION
<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**: This fixes not being able to test components which receive nested arrays in their `style` prop.

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**Why**: react-native allows nested array for the `style` prop. Although it's not explicity written in the [docs](https://facebook.github.io/react-native/docs/style) but TypeScript [typings for react-native](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/cdf01cf33d2db0f25558413ce3ba98b472c4dd07/types/react-native/index.d.ts#L1966) allow it and some libraries (at least [react-native-paper](https://github.com/callstack/react-native-paper)) are making use of them.

<!-- Why are these changes necessary? -->

**How**: We flatten the `style` prop before using `mergeAll`

<!-- How were these changes implemented? -->

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs](https://github.com/testing-library/jest-native/README.md) (N/A)
- [ ] Typescript definitions updated (N/A)
- [x] Tests
- [x] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
