### PR TITLE
Enabling toBeDisabled matcher for TextInput elements

### DIFF
--- a/src/__tests__/to-be-disabled.js
+++ b/src/__tests__/to-be-disabled.js
@@ -6,6 +6,7 @@ import {
   TouchableOpacity,
   TouchableWithoutFeedback,
   View,
+  TextInput,
 } from 'react-native';
 import { render } from '@testing-library/react-native';
 
@@ -13,6 +14,7 @@ test('.toBeDisabled', () => {
   const { queryByTestId, queryByText, queryByTitle } = render(
     <View disabled testID="view">
       <Button disabled testID="button" title="button" />
+      <TextInput accessibilityStates={['disabled']} testID="textInput" value="textInput" />
       <TouchableHighlight disabled testID="highlight">
         <Text>highlight</Text>
       </TouchableHighlight>
@@ -30,6 +32,11 @@ test('.toBeDisabled', () => {
 
   expect(queryByTitle('button')).toBeDisabled();
   expect(() => expect(queryByTitle('button')).not.toBeDisabled()).toThrowError();
+
+  expect(queryByTestId('textInput')).toBeDisabled();
+  expect(queryByText('textInput')).toBeDisabled();
+  expect(() => expect(queryByTestId('textInput')).not.toBeDisabled()).toThrowError();
+  expect(() => expect(queryByText('textInput')).not.toBeDisabled()).toThrowError();
 
   expect(queryByTestId('highlight')).toBeDisabled();
   expect(queryByText('highlight')).toBeDisabled();
@@ -51,6 +58,7 @@ test('.toBeEnabled', () => {
   const { queryByTestId, queryByText, queryByTitle } = render(
     <View testID="view">
       <Button title="button" />
+      <TextInput testID="textInput" value="textInput" />
       <TouchableHighlight testID="highlight">
         <Text>highlight</Text>
       </TouchableHighlight>
@@ -68,6 +76,11 @@ test('.toBeEnabled', () => {
 
   expect(queryByTitle('button')).toBeEnabled();
   expect(() => expect(queryByTitle('button')).not.toBeEnabled()).toThrowError();
+
+  expect(queryByTestId('textInput')).toBeEnabled();
+  expect(queryByText('textInput')).toBeEnabled();
+  expect(() => expect(queryByTestId('textInput')).not.toBeEnabled()).toThrowError();
+  expect(() => expect(queryByText('textInput')).not.toBeEnabled()).toThrowError();
 
   expect(queryByTestId('highlight')).toBeEnabled();
   expect(queryByText('highlight')).toBeEnabled();

--- a/src/__tests__/to-be-disabled.js
+++ b/src/__tests__/to-be-disabled.js
@@ -11,10 +11,10 @@ import {
 import { render } from '@testing-library/react-native';
 
 test('.toBeDisabled', () => {
-  const { queryByTestId, queryByText, queryByTitle } = render(
+  const { queryByTestId, queryByText, queryByTitle, queryByDisplayValue } = render(
     <View disabled testID="view">
       <Button disabled testID="button" title="button" />
-      <TextInput accessibilityStates={['disabled']} testID="textInput" value="textInput" />
+      <TextInput editable={false} testID="textInput" value="textInput" />
       <TouchableHighlight disabled testID="highlight">
         <Text>highlight</Text>
       </TouchableHighlight>
@@ -34,9 +34,9 @@ test('.toBeDisabled', () => {
   expect(() => expect(queryByTitle('button')).not.toBeDisabled()).toThrowError();
 
   expect(queryByTestId('textInput')).toBeDisabled();
-  expect(queryByText('textInput')).toBeDisabled();
+  expect(queryByDisplayValue('textInput')).toBeDisabled();
   expect(() => expect(queryByTestId('textInput')).not.toBeDisabled()).toThrowError();
-  expect(() => expect(queryByText('textInput')).not.toBeDisabled()).toThrowError();
+  expect(() => expect(queryByDisplayValue('textInput')).not.toBeDisabled()).toThrowError();
 
   expect(queryByTestId('highlight')).toBeDisabled();
   expect(queryByText('highlight')).toBeDisabled();
@@ -55,7 +55,7 @@ test('.toBeDisabled', () => {
 });
 
 test('.toBeEnabled', () => {
-  const { queryByTestId, queryByText, queryByTitle } = render(
+  const { queryByTestId, queryByText, queryByTitle, queryByDisplayValue } = render(
     <View testID="view">
       <Button title="button" />
       <TextInput testID="textInput" value="textInput" />
@@ -78,9 +78,9 @@ test('.toBeEnabled', () => {
   expect(() => expect(queryByTitle('button')).not.toBeEnabled()).toThrowError();
 
   expect(queryByTestId('textInput')).toBeEnabled();
-  expect(queryByText('textInput')).toBeEnabled();
+  expect(queryByDisplayValue('textInput')).toBeEnabled();
   expect(() => expect(queryByTestId('textInput')).not.toBeEnabled()).toThrowError();
-  expect(() => expect(queryByText('textInput')).not.toBeEnabled()).toThrowError();
+  expect(() => expect(queryByDisplayValue('textInput')).not.toBeEnabled()).toThrowError();
 
   expect(queryByTestId('highlight')).toBeEnabled();
   expect(queryByText('highlight')).toBeEnabled();

--- a/src/to-be-disabled.js
+++ b/src/to-be-disabled.js
@@ -13,6 +13,7 @@ const DISABLE_TYPES = [
   'TouchableOpacity',
   'TouchableWithoutFeedback',
   'View',
+  'TextInput',
 ];
 
 function isElementDisabledByParent(parent) {


### PR DESCRIPTION
**What**:
Enabling toBeDisabled matcher for TextInput elements

**Why**:
They were ignored before

**How**:
Just added TextInput as a valid disabled element

**Checklist**:
- [x] Documentation added to the
      [docs](https://github.com/testing-library/jest-native/README.md)
- [x] Typescript definitions updated
- [x] Tests
- [x] Ready to be merged <!-- In your opinion -->

Hi! Thanks for this library first of all :)

So I have added some tests but I am having a weird problem with them. It looks like the element is passing as null for some reason. I've tried to update react native and testing library but the issue carries on happening. Wondering if you could help with this little bit and have the PR ready?

Thanks again