### PR TITLE
feat: filter values normally hidden by React

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -66,6 +66,16 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "donovanhiland",
+      "name": "Donovan Hiland",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/17991396?v=4",
+      "profile": "https://github.com/donovanhiland",
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ expect(queryByTestId('count-value')).not.toHaveTextContent('21');
 ### `toHaveStyle`
 
 ```javascript
-toHaveStyle(style: object[] | object);
+toHaveStyle((style: object[] | object));
 ```
 
 Check if an element has the supplied styles.
@@ -314,11 +314,13 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/Shywim"><img src="https://avatars3.githubusercontent.com/u/1584563?v=4" width="100px;" alt=""/><br /><sub><b>Matthieu Harlé</b></sub></a><br /><a href="https://github.com/testing-library/jest-native/commits?author=Shywim" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/acatalina"><img src="https://avatars3.githubusercontent.com/u/23233812?v=4" width="100px;" alt=""/><br /><sub><b>Alvaro Catalina</b></sub></a><br /><a href="https://github.com/testing-library/jest-native/commits?author=acatalina" title="Code">💻</a></td>
     <td align="center"><a href="http://www.ilkeryilmaz.com"><img src="https://avatars1.githubusercontent.com/u/1588236?v=4" width="100px;" alt=""/><br /><sub><b>ilker Yılmaz</b></sub></a><br /><a href="https://github.com/testing-library/jest-native/commits?author=ilkeryilmaz" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://github.com/donovanhiland"><img src="https://avatars2.githubusercontent.com/u/17991396?v=4" width="100px;" alt=""/><br /><sub><b>Donovan Hiland</b></sub></a><br /><a href="https://github.com/testing-library/jest-native/commits?author=donovanhiland" title="Code">💻</a> <a href="https://github.com/testing-library/jest-native/commits?author=donovanhiland" title="Tests">⚠️</a></td>
   </tr>
 </table>
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors)

--- a/src/__tests__/to-have-text-content.js
+++ b/src/__tests__/to-have-text-content.js
@@ -73,4 +73,17 @@ describe('.toHaveTextContent', () => {
     expect(container).toHaveTextContent('Sensitive text');
     expect(container).not.toHaveTextContent('sensitive text');
   });
+
+  test('can handle conditional rendering', () => {
+    const { getByTestId } = render(
+      <Text testID="parent">
+        <Text>Shown</Text>
+        {false && <Text>false</Text>}
+        {null && <Text>null</Text>}
+        {undefined && <Text>undefined</Text>}
+      </Text>,
+    );
+
+    expect(getByTestId('parent')).toHaveTextContent(/^Shown$/);
+  });
 });

--- a/src/to-have-text-content.js
+++ b/src/to-have-text-content.js
@@ -1,5 +1,5 @@
 import { matcherHint } from 'jest-matcher-utils';
-import { compose, defaultTo, is, join, map, path } from 'ramda';
+import { compose, defaultTo, is, join, map, path, filter } from 'ramda';
 
 import { checkReactElement, getMessage, matches, normalize } from './utils';
 
@@ -18,12 +18,14 @@ function getText(child, currentValue = '') {
 export function toHaveTextContent(element, checkWith) {
   checkReactElement(element, toHaveTextContent, this);
 
-  // step 8: enjoy your text content ☺️
+  // step 9: enjoy your text content ☺️
   const textContent = compose(
-    // step 7: strip out extra whitespace
+    // step 8: strip out extra whitespace
     normalize,
-    // step 6: join the resulting array
+    // step 7: join the resulting array
     join(''),
+    // step 6: filter out values hidden by React
+    filter(child => typeof child === 'string' || typeof child === 'number'),
     // step 5: map the array to get text content
     map(child => (typeof child === 'object' ? getText(child) : child)),
     // step 4: make sure non-array children end up in an array


### PR DESCRIPTION
<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
Trying to check for text content in a text node that contains conditional rendering can fail using specifc regex.

For example:
```
<Text testID="parent>
  <Text>Shown</Text>
  {false && <Text>Hidden</Text>}
<Text>

expect(getByTestID('parent')).toHaveTextContent(/^Shown$/)
```
Will fail because the `textContent` resolves to `Shownfalse`

**Why**:

React filters values from being displayed. This changes the text content builder to reflect that.

**How**:

By filtering out values react normally ignores.

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs](https://github.com/testing-library/jest-native/README.md)
- [ ] Typescript definitions updated
- [X] Tests
- [X] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
