### PR TITLE
.toHaveStyle() to support transform styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,8 +260,8 @@ expect(queryByTestId('count-value')).not.toHaveTextContent('21');
 
 ### `toHaveStyle`
 
-```javascript
-toHaveStyle((style: object[] | object));
+```typescript
+toHaveStyle(style: object[] | object);
 ```
 
 Check if an element has the supplied styles.

--- a/README.md
+++ b/README.md
@@ -261,13 +261,13 @@ expect(queryByTestId('count-value')).not.toHaveTextContent('21');
 ### `toHaveStyle`
 
 ```javascript
-toHaveStyle(style: object[] | object);
+toHaveStyle((style: object[] | object));
 ```
 
 Check if an element has the supplied styles.
 
 You can pass either an object of React Native style properties, or an array of objects with style
-properties. You cannot pass properties from a React Native stylesheet..
+properties. You cannot pass properties from a React Native stylesheet.
 
 #### Examples
 
@@ -275,13 +275,22 @@ properties. You cannot pass properties from a React Native stylesheet..
 const styles = StyleSheet.create({ text: { fontSize: 16 } });
 
 const { queryByText } = render(
-  <Text style={[{ color: 'black', fontWeight: '600' }, styles.text]}>Hello World</Text>,
+  <Text
+    style={[
+      { color: 'black', fontWeight: '600', transform: [{ scale: 2 }, { rotate: '45deg' }] },
+      styles.text,
+    ]}
+  >
+    Hello World
+  </Text>,
 );
 
 expect(queryByText('Hello World')).toHaveStyle({ color: 'black', fontWeight: '600', fontSize: 16 });
 expect(queryByText('Hello World')).toHaveStyle({ color: 'black' });
 expect(queryByText('Hello World')).toHaveStyle({ fontWeight: '600' });
 expect(queryByText('Hello World')).toHaveStyle({ fontSize: 16 });
+expect(queryByText('Hello World')).toHaveStyle({ transform: [{ scale: 2 }, { rotate: '45deg' }] });
+expect(queryByText('Hello World')).toHaveStyle({ transform: [{ rotate: '45deg' }] });
 expect(queryByText('Hello World')).toHaveStyle([{ color: 'black' }, { fontWeight: '600' }]);
 expect(queryByText('Hello World')).not.toHaveStyle({ color: 'white' });
 ```
@@ -319,6 +328,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors)

--- a/src/__tests__/__snapshots__/to-have-style.js.snap
+++ b/src/__tests__/__snapshots__/to-have-style.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.toHaveStyle handles negative test cases 1`] = `
+"<dim>expect(</><red>element</><dim>).toHaveStyle()</>
+
+<green>- Expected</>
+
+<dim>  backgroundColor: blue;</>
+<dim>  transform: [</>
+<dim>    {</>
+<green>-     \\"scale\\": 1</>
+<red>+     \\"scale\\": 2</>
+<dim>    }</>
+<dim>  ];</>"
+`;
+
+exports[`.toHaveStyle handles transform when transform undefined 1`] = `
+"<dim>expect(</><red>element</><dim>).toHaveStyle()</>
+
+<green>- Expected</>
+
+<green>- transform: [</>
+<green>-   {</>
+<green>-     \\"scale\\": 1</>
+<green>-   }</>
+<green>- ];</>
+<red>+ transform: undefined;</>"
+`;

--- a/src/__tests__/to-have-style.js
+++ b/src/__tests__/to-have-style.js
@@ -8,7 +8,15 @@ describe('.toHaveStyle', () => {
     const { getByTestId } = render(
       <View
         testID="container"
-        style={[{ backgroundColor: 'blue', height: '100%' }, [{ width: '50%' }], styles.container]}
+        style={[
+          {
+            backgroundColor: 'blue',
+            height: '100%',
+            transform: [{ scale: 2 }, { rotate: '45deg' }],
+          },
+          [{ width: '50%' }],
+          styles.container,
+        ]}
       >
         <Text>Hello World</Text>
       </View>,
@@ -22,18 +30,49 @@ describe('.toHaveStyle', () => {
     expect(container).toHaveStyle({ height: '100%' });
     expect(container).toHaveStyle({ color: 'white' });
     expect(container).toHaveStyle({ width: '50%' });
+    expect(container).toHaveStyle({ transform: [{ scale: 2 }, { rotate: '45deg' }] });
+    expect(container).toHaveStyle({ transform: [{ rotate: '45deg' }] });
   });
 
   test('handles negative test cases', () => {
     const { getByTestId } = render(
-      <View testID="container" style={{ backgroundColor: 'blue', color: 'black', height: '100%' }}>
+      <View
+        testID="container"
+        style={{
+          backgroundColor: 'blue',
+          color: 'black',
+          height: '100%',
+          transform: [{ scale: 2 }, { rotate: '45deg' }],
+        }}
+      >
         <Text>Hello World</Text>
       </View>,
     );
 
     const container = getByTestId('container');
-
+    expect(() =>
+      expect(container).toHaveStyle({ backgroundColor: 'blue', transform: [{ scale: 1 }] }),
+    ).toThrowErrorMatchingSnapshot();
     expect(() => expect(container).toHaveStyle({ fontWeight: 'bold' })).toThrowError();
     expect(() => expect(container).not.toHaveStyle({ color: 'black' })).toThrowError();
+  });
+
+  test('handles transform when transform undefined', () => {
+    const { getByTestId } = render(
+      <View
+        testID="container"
+        style={{
+          backgroundColor: 'blue',
+          transform: undefined,
+        }}
+      >
+        <Text>Hello World</Text>
+      </View>,
+    );
+
+    const container = getByTestId('container');
+    expect(() =>
+      expect(container).toHaveStyle({ transform: [{ scale: 1 }] }),
+    ).toThrowErrorMatchingSnapshot();
   });
 });


### PR DESCRIPTION
**What**:

Adds ability for `.toHaveStyle()` to compare `transform` styles.

**Why**:

Previously, `.toHaveStyle()` would only operate on shallow style properties, but transforms are specified as an `object[]`. The transform values would then be compared using strict equality and as such would never pass.

Furthermore, the diffs would serialize the transform values as `[object Object]` making both sides appear to be equal. 

Ultimately, the test would fail regardless but the diff would tell us that everything is fine.

![image](https://user-images.githubusercontent.com/309607/80654894-44e6bb00-8a75-11ea-8a1c-9902616f0381.png)

**How**:

We're now properly handling any style properties with `object[]` values and correctly serializing the `expected` and `received` passed to `jestDiff`. In both cases using recursion to perform the deep checks.

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs](https://github.com/testing-library/jest-native/README.md)
- [ ] Typescript definitions updated (N/A)
- [x] Tests
- [x] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->

I noticed that up until now, there have been no snapshots assertions, but I've added two small snapshots of the `jestDiff` output due to the added complexity in their generation. I think it's important to capture this — hope you don't mind.