### PR TITLE
feat(toHaveStyle): handle when the prop style is undefined

### DIFF
--- a/src/__tests__/to-have-style.js
+++ b/src/__tests__/to-have-style.js
@@ -36,4 +36,16 @@ describe('.toHaveStyle', () => {
     expect(() => expect(container).toHaveStyle({ fontWeight: 'bold' })).toThrowError();
     expect(() => expect(container).not.toHaveStyle({ color: 'black' })).toThrowError();
   });
+
+  test('handles when the style prop is undefined', () => {
+    const { getByTestId } = render(
+      <View testID="container">
+        <Text>Hello World</Text>
+      </View>,
+    );
+
+    const container = getByTestId('container');
+
+    expect(container).not.toHaveStyle({ fontWeight: 'bold' });
+  });
 });

--- a/src/to-have-style.js
+++ b/src/to-have-style.js
@@ -38,7 +38,7 @@ function expectedDiff(expected, elementStyles) {
 export function toHaveStyle(element, style) {
   checkReactElement(element, toHaveStyle, this);
 
-  const elementStyle = element.props.style;
+  const elementStyle = element.props.style ?? {};
 
   const expected = Array.isArray(style) ? mergeAllStyles(style) : style;
   const received = Array.isArray(elementStyle) ? mergeAllStyles(elementStyle) : elementStyle;


### PR DESCRIPTION
**What**:
Now the matcher `toHaveStyle` can handle elements without style.

**Why**:
It's useful to check whether an element has a style or not when conditionally applying a style.

**How**:
I've added a default value `{}` to the `received` styles.

<!-- How were these changes implemented? -->

**Checklist**:
- [N/A] Documentation added to the [docs](https://github.com/testing-library/jest-native/README.md)
- [N/A] Typescript definitions updated
- [x] Tests
- [x] Ready to be merged
