### PR TITLE
feat: support RN 0.63 Pressable in toBeDisabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@babel/cli": "7.2.3",
     "@babel/core": "7.4.0",
     "@babel/runtime": "7.4.0",
-    "@testing-library/react-native": "^4.0.1",
+    "@testing-library/react-native": "^6.0.0",
     "commitizen": "^3.0.7",
     "cz-conventional-changelog": "^2.1.0",
     "husky": "^1.3.1",
@@ -48,7 +48,7 @@
     "prettier": "^1.16.4",
     "pretty-quick": "^1.10.0",
     "react": "16.8.6",
-    "react-native": "^0.59.6",
+    "react-native": "0.63.2",
     "react-test-renderer": "16.8.6",
     "semantic-release": "^15.13.3"
   },

--- a/src/__tests__/to-be-disabled.js
+++ b/src/__tests__/to-be-disabled.js
@@ -6,6 +6,7 @@ import {
   TouchableWithoutFeedback,
   View,
   TextInput,
+  Pressable,
 } from 'react-native';
 import { render } from '@testing-library/react-native';
 
@@ -16,6 +17,7 @@ const ALLOWED_COMPONENTS = {
   TouchableHighlight,
   TouchableOpacity,
   TouchableWithoutFeedback,
+  Pressable,
 };
 
 describe('.toBeDisabled', () => {

--- a/src/to-be-disabled.js
+++ b/src/to-be-disabled.js
@@ -14,6 +14,7 @@ const DISABLE_TYPES = [
   'TouchableWithoutFeedback',
   'View',
   'TextInput',
+  'Pressable',
 ];
 
 function isElementDisabledByParent(parent) {


### PR DESCRIPTION
**What**:

Updated jest-native to support RN 0.63 Pressable component in toBeDisabled.

**Why**:

When testing a Pressable component the test always fails. 

**How**:

Updated dependencies to support RN 0.63. Added Pressable to supported Types.

**Checklist**:

- [ ] Documentation added to the
      [docs](https://github.com/testing-library/jest-native/README.md) (N/A)
- [ ] Typescript definitions updated (N/A)
- [X] Tests
- [X] Ready to be merged

Related to issue https://github.com/testing-library/jest-native/issues/23
