### PR TITLE
fix: toHaveProp func to work with @testing-library/react-native latest version (7.0.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ These will make your tests more declarative, clear to read and to maintain.
 
 These matchers should, for the most part, be agnostic enough to work with any React Native testing
 utilities, but they are primarily intended to be used with
-[RNTL](https://github.com/testing-library/native-testing-library). Any issues raised with existing
+[RNTL](https://github.com/callstack/react-native-testing-library). Any issues raised with existing
 matchers or any newly proposed matchers must be viewed through compatibility with that library and
 its guiding principles first.
 
@@ -271,7 +271,7 @@ toHaveStyle((style: object[] | object));
 Check if an element has the supplied styles.
 
 You can pass either an object of React Native style properties, or an array of objects with style
-properties. You cannot pass properties from a React Native stylesheet..
+properties. You cannot pass properties from a React Native stylesheet.
 
 #### Examples
 
@@ -293,7 +293,7 @@ expect(queryByText('Hello World')).not.toHaveStyle({ color: 'white' });
 ## Inspiration
 
 This library was made to be a companion for
-[RNTL](https://github.com/testing-library/native-testing-library).
+[RNTL](https://github.com/callstack/react-native-testing-library).
 
 It was inspired by [jest-dom](https://github.com/gnapse/jest-dom/), the companion library for
 [DTL](https://github.com/kentcdodds/dom-testing-library/). We emulated as many of those helpers as

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ expect(parent).not.toContainElement(grandparent);
 toHaveProp(prop: string, value?: any);
 ```
 
-Check that an element has a given prop. this is similar to checking for attributes in the DOM.
+Check that an element has a given prop.
 
 You can optionally check that the attribute has a specific expected value.
 

--- a/README.md
+++ b/README.md
@@ -215,8 +215,7 @@ expect(parent).not.toContainElement(grandparent);
 toHaveProp(prop: string, value?: any);
 ```
 
-Check that an element has a given prop. Only works for native elements, so this is similar to
-checking for attributes in the DOM.
+Check that an element has a given prop. this is similar to checking for attributes in the DOM.
 
 You can optionally check that the attribute has a specific expected value.
 

--- a/src/__tests__/to-have-prop.js
+++ b/src/__tests__/to-have-prop.js
@@ -3,7 +3,7 @@ import { Button, Text, View } from 'react-native';
 import { render } from '@testing-library/react-native';
 
 test('.toHaveProp', () => {
-  const { queryByTestId } = render(
+  const { queryByTestId, getByText } = render(
     <View>
       <Text allowFontScaling={false} testID="text">
         text
@@ -30,4 +30,7 @@ test('.toHaveProp', () => {
     expect(queryByTestId('text')).not.toHaveProp('allowFontScaling', false),
   ).toThrowError();
   expect(() => expect(queryByTestId('text')).toHaveProp('style')).toThrowError();
+  expect(() =>
+    expect(getByText('text')).toHaveProp('allowFontScaling', 'wrongValue'),
+  ).toThrowError();
 });

--- a/src/__tests__/to-have-prop.js
+++ b/src/__tests__/to-have-prop.js
@@ -3,7 +3,7 @@ import { Button, Text, View } from 'react-native';
 import { render } from '@testing-library/react-native';
 
 test('.toHaveProp', () => {
-  const { queryByTestId, getByText } = render(
+  const { queryByTestId } = render(
     <View>
       <Text allowFontScaling={false} testID="text">
         text

--- a/src/__tests__/to-have-prop.js
+++ b/src/__tests__/to-have-prop.js
@@ -31,6 +31,6 @@ test('.toHaveProp', () => {
   ).toThrowError();
   expect(() => expect(queryByTestId('text')).toHaveProp('style')).toThrowError();
   expect(() =>
-    expect(getByText('text')).toHaveProp('allowFontScaling', 'wrongValue'),
+    expect(queryByTestId('text')).toHaveProp('allowFontScaling', 'wrongValue'),
   ).toThrowError();
 });

--- a/src/to-have-prop.js
+++ b/src/to-have-prop.js
@@ -1,6 +1,6 @@
 import { equals, isNil, not } from 'ramda';
 import { matcherHint, stringify, printExpected } from 'jest-matcher-utils';
-import { checkReactElement, getMessage, VALID_ELEMENTS } from './utils';
+import { checkReactElement, getMessage } from './utils';
 
 function printAttribute(name, value) {
   return value === undefined ? name : `${name}=${stringify(value)}`;

--- a/src/to-have-prop.js
+++ b/src/to-have-prop.js
@@ -18,7 +18,8 @@ export function toHaveProp(element, name, expectedValue) {
   const prop = element.props[name];
 
   const isDefined = expectedValue !== undefined;
-  const isAllowed = VALID_ELEMENTS.includes(element.type);
+  const elementType = typeof element.type == 'string' ? element.type : element.type?.displayName;
+  const isAllowed = VALID_ELEMENTS.includes(elementType);
   const hasProp = not(isNil(prop));
 
   return {

--- a/src/to-have-prop.js
+++ b/src/to-have-prop.js
@@ -18,12 +18,10 @@ export function toHaveProp(element, name, expectedValue) {
   const prop = element.props[name];
 
   const isDefined = expectedValue !== undefined;
-  const elementType = typeof element.type == 'string' ? element.type : element.type?.displayName;
-  const isAllowed = VALID_ELEMENTS.includes(elementType);
   const hasProp = not(isNil(prop));
 
   return {
-    pass: isDefined && isAllowed ? hasProp && equals(prop, expectedValue) : hasProp,
+    pass: isDefined ? hasProp && equals(prop, expectedValue) : hasProp,
     message: () => {
       const to = this.isNot ? 'not to' : 'to';
       const receivedProp = hasProp ? printAttribute(name, prop) : null;

--- a/src/utils.js
+++ b/src/utils.js
@@ -99,5 +99,4 @@ export {
   matches,
   normalize,
   printElement,
-  VALID_ELEMENTS,
 };


### PR DESCRIPTION
<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**:

when using the latest @testing-library/react-native version, the function `toHaveProp(attr: string, value?: any)` doesn't work properly when getting the element *by text*, it checks for the prop existence but does not compare to the expected value, when given, and returns 'pass' even if the expected value is wrong.

**Why**:

to be able to work with this function using the new version of @testing-library/react-native

**How**:

just changed a couple of row in to-have-props.js

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the 
      [docs](https://github.com/testing-library/jest-native/README.md) (N/A)
- [ ] Typescript definitions updated (N/A)
- [X] Tests
- [X] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
to recreate the issue, you can checkout this [branch](https://github.com/khealth/jest-native/tree/recreate_toHaveProp_bug)