### PR TITLE
fix: Update Matchers types

### DIFF
--- a/extend-expect.d.ts
+++ b/extend-expect.d.ts
@@ -2,7 +2,7 @@ import { ReactTestInstance } from 'react-test-renderer';
 
 declare global {
   namespace jest {
-    interface Matchers<R> {
+    interface Matchers<R, T> {
       toBeDisabled(): R;
       toContainElement(element: ReactTestInstance | null): R;
       toBeEmpty(): R;


### PR DESCRIPTION
Update `Matchers` types due to @types/jest breaking change

<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
Fix an issue where autocomplete doesn't work properly in `*.[test|spec].tsx` files

**Why**:

<!-- Why are these changes necessary? -->
Keep the interfaces up-to-date with @types/jest

**How**:

<!-- How were these changes implemented? -->
Set `Matchers` interface generic types as `<R, T>`

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs](https://github.com/testing-library/jest-native/README.md) (N/A)
- [x] Typescript definitions updated
- [ ] Tests (N/A)
- [x] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
Fixes #25, fixes #21 