### PR TITLE
test: snapshot toHaveStyle diff output

### DIFF
--- a/src/__tests__/__snapshots__/to-have-style.js.snap
+++ b/src/__tests__/__snapshots__/to-have-style.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.toHaveStyle handles negative test cases 1`] = `
+"<dim>expect(</><red>element</><dim>).toHaveStyle()</>
+
+<green>- Expected</>
+
+<dim>  backgroundColor: blue;</>
+<dim>  transform: [</>
+<dim>    {</>
+<green>-     \\"scale\\": 1</>
+<red>+     \\"scale\\": 2</>
+<dim>    }</>
+<dim>  ];</>"
+`;
+
+exports[`.toHaveStyle handles transform when transform undefined 1`] = `
+"<dim>expect(</><red>element</><dim>).toHaveStyle()</>
+
+<green>- Expected</>
+
+<green>- transform: [</>
+<green>-   {</>
+<green>-     \\"scale\\": 1</>
+<green>-   }</>
+<green>- ];</>
+<red>+ transform: undefined;</>"
+`;

--- a/src/__tests__/to-have-style.js
+++ b/src/__tests__/to-have-style.js
@@ -52,7 +52,7 @@ describe('.toHaveStyle', () => {
     const container = getByTestId('container');
     expect(() =>
       expect(container).toHaveStyle({ backgroundColor: 'blue', transform: [{ scale: 1 }] }),
-    ).toThrowError();
+    ).toThrowErrorMatchingSnapshot();
     expect(() => expect(container).toHaveStyle({ fontWeight: 'bold' })).toThrowError();
     expect(() => expect(container).not.toHaveStyle({ color: 'black' })).toThrowError();
   });
@@ -83,6 +83,8 @@ describe('.toHaveStyle', () => {
     );
 
     const container = getByTestId('container');
-    expect(() => expect(container).toHaveStyle({ transform: [{ scale: 1 }] })).toThrowError();
+    expect(() =>
+      expect(container).toHaveStyle({ transform: [{ scale: 1 }] }),
+    ).toThrowErrorMatchingSnapshot();
   });
 });


### PR DESCRIPTION
<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**:

Reimplement the snapshot tests for `toHaveStyle`

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**Why**:

See discussion here:
https://github.com/testing-library/jest-native/commit/f0f434643b3b54da7be242660dc4a34b5efc9cfa#r42121221

**tl;dr** @brunohkbx discovered a problem running the tests with snapshots as part of #26 , so let's isolate this change to more effectively debug. Testing the output diff is important as it's key feedback users rely on when a test fails.


**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs](https://github.com/testing-library/jest-native/README.md) (N/A)
- [ ] Typescript definitions updated (N/A)
- [x] Tests
- [x] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
