### PR TITLE
chore: run jest with --colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
     "commit:add": "git add .",
     "commit:all": "npm run commit:add && npm run commit",
     "readme:toc": "doctoc README.md --maxlevel 3 --title '## Table of Contents'",
-    "test": "jest",
+    "test": "jest --colors",
     "pretty-quick": "pretty-quick --staged",
     "prepublishOnly": "rm -rf dist; babel src --out-dir dist --ignore 'src/__tests__/*'",
     "semantic-release": "semantic-release",
-    "test:coverage": "jest --coverage",
+    "test:coverage": "jest --coverage --colors",
     "test:watch": "jest --watch --coverage"
   },
   "files": [


### PR DESCRIPTION
**What**:
This PR is an attempt to fix breaking snapshot tests on master.

**Why**:
Looks like travis has a different output color when running jest on master as discussed in #42, so it's breaking snapshot tests. 

**How**
Running jest with `--colors` might fix.

**Checklist**:

- [ ] Documentation added to the
      [docs](https://github.com/testing-library/jest-native/README.md)
- [ ] Typescript definitions updated
- [ ] Tests
- [x] Ready to be merged