### PR TITLE
feat(breaking): toHaveTextContent supports nested arrays of sibling elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ package.
 ## Usage
 
 Import `@testing-library/jest-native/extend-expect` once (for instance in your
-[tests setup file](https://jestjs.io/docs/en/configuration.html#setupfilesafterenv-array))
-and you're good to go:
+[tests setup file](https://jestjs.io/docs/en/configuration.html#setupfilesafterenv-array)) and
+you're good to go:
 
 ```javascript
 import '@testing-library/jest-native/extend-expect';
@@ -243,7 +243,7 @@ expect(queryByTestId('button')).not.toHaveProp('title', 'ok');
 toHaveTextContent(text: string | RegExp, options?: { normalizeWhitespace: boolean });
 ```
 
-Check if an element has the supplied text.
+Check if an element or its children have the supplied text.
 
 This will perform a partial, case-sensitive match when a string match is provided. To perform a
 case-insensitive match, you can use a `RegExp` with the `/i` modifier.

--- a/src/__tests__/to-have-text-content.js
+++ b/src/__tests__/to-have-text-content.js
@@ -49,17 +49,27 @@ describe('.toHaveTextContent', () => {
 
   test('can handle multiple levels with content spread across descendants', () => {
     const { queryByTestId } = render(
-      <Text testID="parent">
-        <Text>Step</Text>
-        <Text> 1 </Text>
+      <View testID="parent">
+        <Text>One</Text>
+        <Text>Two</Text>
         <View>
-          <Text> of </Text>
+          <Text>Three</Text>
         </View>
-        4
-      </Text>,
+        <View>
+          <Text>Four</Text>
+          {null}
+          <Text>Five</Text>
+          <View>
+            <Text>Six</Text>
+            <Text>Seven</Text>
+          </View>
+          <Text>Eight</Text>
+        </View>
+        Nine
+      </View>,
     );
 
-    expect(queryByTestId('parent')).toHaveTextContent('Step 1 of 4');
+    expect(queryByTestId('parent')).toHaveTextContent('OneTwoThreeFourFiveSixSevenEightNine');
   });
 
   test('does not throw error with empty content', () => {

--- a/src/to-have-text-content.js
+++ b/src/to-have-text-content.js
@@ -8,6 +8,8 @@ function getText(child, currentValue = '') {
 
   if (!child) {
     return value;
+  } else if (Array.isArray(child)) {
+    return child.reduce((acc, element) => acc + getText(path(['props', 'children'], element)), '');
   } else if (typeof child === 'object') {
     return getText(path(['props', 'children'], child), value);
   } else {


### PR DESCRIPTION
BREAKING CHANGE: toHaveTextContent may produce more output in some cases due to including all nested sibling elements

<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

`toHaveTextContent` currently supports recursion, but it would only handle the first child element of a deeply nested child.

This existing test would of course pass:
https://github.com/testing-library/jest-native/blob/master/src/__tests__/to-have-text-content.js#L50-L63

But add a sibling element to the nested `View` and it would fail to include the ` additional text ` of said element. In this example, it would receive: `Step 1 4`

```js
<Text testID="parent">
  <Text>Step</Text>
  <Text> 1 </Text>
  <View>
    <Text> of </Text>
    <Text> additional text </Text> // <-- toHaveTextContent would never parse this 
  </View>
  4
</Text>
```

**Why**:

<!-- Why are these changes necessary? -->

`toHaveTextContent` should parse all nested elements including siblings, not just the first child of a nested element.

**How**:

<!-- How were these changes implemented? -->

When the element being parsed is an array, loop through the array and recursively use `getText` to retrieve its text content.

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs](https://github.com/testing-library/jest-native/README.md)
- [ ] Typescript definitions updated (N/A)
- [x] Tests
- [x] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->

**Please note:**
I've flagged this as a breaking change due to the possibility that there may be tests out in the wild that have ignored the fact that `toHaveTextContent` didn't return the full text of all descendant elements. But if you feel that it's very much an edge case, then I'd be happy to recategorise this as a fix/patch.