### PR TITLE
fix: Fix toBeDisabled for TouchableNativeFeedback

### DIFF
--- a/src/__tests__/to-be-disabled.js
+++ b/src/__tests__/to-be-disabled.js
@@ -4,6 +4,7 @@ import {
   TouchableHighlight,
   TouchableOpacity,
   TouchableWithoutFeedback,
+  TouchableNativeFeedback,
   View,
   TextInput,
   Pressable,
@@ -17,6 +18,7 @@ const ALLOWED_COMPONENTS = {
   TouchableHighlight,
   TouchableOpacity,
   TouchableWithoutFeedback,
+  TouchableNativeFeedback,
   Pressable,
 };
 

--- a/src/to-be-disabled.js
+++ b/src/to-be-disabled.js
@@ -12,6 +12,7 @@ const DISABLE_TYPES = [
   'TouchableHighlight',
   'TouchableOpacity',
   'TouchableWithoutFeedback',
+  'TouchableNativeFeedback',
   'View',
   'TextInput',
   'Pressable',


### PR DESCRIPTION
**What**:

`TouchableNativeFeedback` wasn't included in the list of components that have a `disabled` prop. As such, `toBeDisabled` would always return `false`.

**Why**:

Because Android is important too 😄 

**How**:

Simply added `TouchableNativeFeedback` to the allow list of components.

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs](https://github.com/testing-library/jest-native/README.md) — N/A
- [ ] Typescript definitions updated — N/A
- [x] Tests
- [x] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
