### PR TITLE
fix: toHaveTextContent supports interpolated variables

### DIFF
--- a/src/__tests__/to-have-text-content.js
+++ b/src/__tests__/to-have-text-content.js
@@ -96,4 +96,11 @@ describe('.toHaveTextContent', () => {
 
     expect(getByTestId('parent')).toHaveTextContent(/^Shown$/);
   });
+
+  test('can handle text with an interpolated variable', () => {
+    const variable = 'variable';
+    const { container } = render(<Text>With a {variable}</Text>);
+
+    expect(container).toHaveTextContent('With a variable');
+  });
 });

--- a/src/to-have-text-content.js
+++ b/src/to-have-text-content.js
@@ -1,5 +1,5 @@
 import { matcherHint } from 'jest-matcher-utils';
-import { compose, defaultTo, is, join, map, path, filter } from 'ramda';
+import { compose, defaultTo, is, join, map, path, filter, pathOr } from 'ramda';
 
 import { checkReactElement, getMessage, matches, normalize } from './utils';
 
@@ -9,7 +9,7 @@ function getText(child, currentValue = '') {
   if (!child) {
     return value;
   } else if (Array.isArray(child)) {
-    return child.reduce((acc, element) => acc + getText(path(['props', 'children'], element)), '');
+    return child.reduce((acc, element) => acc + getText(element), '');
   } else if (typeof child === 'object') {
     return getText(path(['props', 'children'], child), value);
   } else {

--- a/src/to-have-text-content.js
+++ b/src/to-have-text-content.js
@@ -1,5 +1,5 @@
 import { matcherHint } from 'jest-matcher-utils';
-import { compose, defaultTo, is, join, map, path, filter, pathOr } from 'ramda';
+import { compose, defaultTo, is, join, map, path, filter } from 'ramda';
 
 import { checkReactElement, getMessage, matches, normalize } from './utils';
 


### PR DESCRIPTION
**What**:

Fix a bug where text content that gets split into an array does not get evaluated by the `toHaveTextContent` matcher.

**Why**:

There's a test case in the PR, but this test case currently fails in master:
```
    const variable = 'variable';
    const { container } = render(<Text>With a {variable}</Text>);

    expect(container).toHaveTextContent('With a variable');

    // Expected element to have text content:
         // With a variable
    // Received:
```

**How**:
The bug was in treating all array elements as react nodes that had a path of `['props', 'children']` that could be traversed to get the text content. The fix is to pass the element directly into the recursive `getText` call and let the conditional logic determine how to extract the text.

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs](https://github.com/testing-library/jest-native/README.md) N/A
- [ ] Typescript definitions updated N/A
- [x] Tests
- [x] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
