### PR TITLE
fix: toHaveTextContent collect properly text of children nodes

### DIFF
--- a/src/__tests__/to-have-text-content.js
+++ b/src/__tests__/to-have-text-content.js
@@ -72,6 +72,32 @@ describe('.toHaveTextContent', () => {
     expect(queryByTestId('parent')).toHaveTextContent('OneTwoThreeFourFiveSixSevenEightNine');
   });
 
+  test('can handle multiple levels with no explicit children prop', () => {
+    const NoChildren = ({ text }) => <Text>{text}</Text>;
+    const answer = 'Answer';
+    const { container } = render(
+      <View>
+        <Text>
+          {answer}
+          {': '}
+        </Text>
+        <NoChildren text="4" />
+        {null}
+        <Text>2</Text>
+      </View>,
+    );
+
+    expect(container).toHaveTextContent(/^Answer: 42$/);
+  });
+
+  test('throws when no match is found', () => {
+    const { container } = render(<Text>Should succeed</Text>);
+
+    expect(() => {
+      expect(container).toHaveTextContent('Should fail');
+    }).toThrow();
+  });
+
   test('does not throw error with empty content', () => {
     const { container } = render(<Text />);
     expect(container).toHaveTextContent('');

--- a/src/to-have-text-content.js
+++ b/src/to-have-text-content.js
@@ -1,24 +1,17 @@
 import { matcherHint } from 'jest-matcher-utils';
-import pipe from 'ramda/src/pipe';
-import always from 'ramda/src/always';
-import is from 'ramda/src/is';
-import join from 'ramda/src/join';
-import reduce from 'ramda/src/reduce';
-import concat from 'ramda/src/concat';
-import unless from 'ramda/src/unless';
-
 import { checkReactElement, getMessage, matches, normalize } from './utils';
 
-const unlessStringEmpty = unless(is(String), always(''));
-
-const collectNormalizedText = pipe(collectChildrenText, join(''), normalize);
+function collectNormalizedText(element) {
+  const childrenText = collectChildrenText(element).join('');
+  return normalize(childrenText);
+}
 
 function collectChildrenText(element) {
   if (!element || !element.children) {
-    return [unlessStringEmpty(element)];
+    return typeof element === 'string' ? [element] : [''];
   }
 
-  return reduce((texts, child) => concat(texts, collectChildrenText(child)), [], element.children);
+  return element.children.reduce((texts, child) => texts.concat(collectChildrenText(child)), []);
 }
 
 export function toHaveTextContent(element, checkWith) {

--- a/src/to-have-text-content.js
+++ b/src/to-have-text-content.js
@@ -1,49 +1,30 @@
 import { matcherHint } from 'jest-matcher-utils';
-import compose from 'ramda/src/compose';
-import defaultTo from 'ramda/src/defaultTo';
+import pipe from 'ramda/src/pipe';
+import always from 'ramda/src/always';
 import is from 'ramda/src/is';
 import join from 'ramda/src/join';
-import map from 'ramda/src/map';
-import path from 'ramda/src/path';
-import filter from 'ramda/src/filter';
+import reduce from 'ramda/src/reduce';
+import concat from 'ramda/src/concat';
+import unless from 'ramda/src/unless';
 
 import { checkReactElement, getMessage, matches, normalize } from './utils';
 
-function getText(child, currentValue = '') {
-  let value = currentValue;
+const unlessStringEmpty = unless(is(String), always(''));
 
-  if (!child) {
-    return value;
-  } else if (Array.isArray(child)) {
-    return child.reduce((acc, element) => acc + getText(element), '');
-  } else if (typeof child === 'object') {
-    return getText(path(['props', 'children'], child), value);
-  } else {
-    return `${value}${child}`;
+const collectNormalizedText = pipe(collectChildrenText, join(''), normalize);
+
+function collectChildrenText(element) {
+  if (!element || !element.children) {
+    return [unlessStringEmpty(element)];
   }
+
+  return reduce((texts, child) => concat(texts, collectChildrenText(child)), [], element.children);
 }
 
 export function toHaveTextContent(element, checkWith) {
   checkReactElement(element, toHaveTextContent, this);
 
-  // step 9: enjoy your text content ☺️
-  const textContent = compose(
-    // step 8: strip out extra whitespace
-    normalize,
-    // step 7: join the resulting array
-    join(''),
-    // step 6: filter out values hidden by React
-    filter(child => typeof child === 'string' || typeof child === 'number'),
-    // step 5: map the array to get text content
-    map(child => (typeof child === 'object' ? getText(child) : child)),
-    // step 4: make sure non-array children end up in an array
-    child => (is(Array, child) ? child : [child]),
-    // step 3: default to an array
-    defaultTo([]),
-    // step 2: drill down to the children
-    path(['props', 'children']),
-    // step 1: get the element
-  )(element);
+  const textContent = collectNormalizedText(element);
 
   return {
     pass: matches(textContent, checkWith),


### PR DESCRIPTION
<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**:

I've fixed #60 but this also cover the fixes from #59 (I've also **copied** the PR author test... but if the author wishes to merge his changes first and then have me apply my changes  and rewrite this PR I can do it)

I've also added a missing test to assure that `toHaveTextContent` fails when it should

**Why**:

Described in #60, but to summarize: `toHaveTextContent` wasn't collecting properly children nodes to find text

**How**:

I've made a simple recursive function that transverses all children collecting text childs and join them for the match comparison

**Checklist**:

<!-- Have you done all of these things?  -->

- [x] Documentation added to the  [docs](https://github.com/testing-library/jest-native/README.md) (N/A)
- [x] Typescript definitions updated (N/A) - signatures doesn't change
- [x] Tests
- [x] Ready to be merged: all the tests are passing, so I'm assuming that this PR only fixes the current behaviour.


* I've only used ramda compositions because this project seems to be using ramda, but if you wish I can rewrite things without ramda.
* For another PR: I would recommend using babel-transform-imports for ramda imports (transform `import {target} from 'ramda'` to `import target from 'ramda/es/{target}'`), this would speed up things a little for jest/babel as it would not need to bundle/collect a lot of unused ramda functions from the ramda index.js
