### PR TITLE
fix(toHaveProp): check null values

### DIFF
--- a/src/__tests__/to-have-prop.js
+++ b/src/__tests__/to-have-prop.js
@@ -2,9 +2,9 @@ import React from 'react';
 import { Button, Text, View } from 'react-native';
 import { render } from '@testing-library/react-native';
 
-test('.toHaveProp', () => {
+describe('.toHaveProp', () => {
   const { queryByTestId } = render(
-    <View>
+    <View accessibilityLabel={null} testID="view">
       <Text allowFontScaling={false} testID="text">
         text
       </Text>
@@ -33,4 +33,8 @@ test('.toHaveProp', () => {
   expect(() =>
     expect(queryByTestId('text')).toHaveProp('allowFontScaling', 'wrongValue'),
   ).toThrowError();
+
+  it('checks null values', () => {
+    expect(queryByTestId('view')).toHaveProp('accessibilityLabel', null);
+  });
 });

--- a/src/to-have-prop.js
+++ b/src/to-have-prop.js
@@ -1,4 +1,4 @@
-import { equals, isNil, not } from 'ramda';
+import { equals } from 'ramda';
 import { matcherHint, stringify, printExpected } from 'jest-matcher-utils';
 import { checkReactElement, getMessage } from './utils';
 
@@ -18,7 +18,7 @@ export function toHaveProp(element, name, expectedValue) {
   const prop = element.props[name];
 
   const isDefined = expectedValue !== undefined;
-  const hasProp = not(isNil(prop));
+  const hasProp = name in element.props;
 
   return {
     pass: isDefined ? hasProp && equals(prop, expectedValue) : hasProp,


### PR DESCRIPTION
**What**:
This PR fixes the matcher toHaveProp

**Why**:
It wasn't  possible to check for null values

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs](https://github.com/testing-library/jest-native/README.md)
- [ ] Typescript definitions updated
- [x] Tests
- [x] Ready to be merged <!-- In your opinion -->