### PR TITLE
perf(ramda): Use individual imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "jest-diff": "^27.4.6",
     "jest-matcher-utils": "^27.4.6",
     "pretty-format": "^27.3.1",
-    "ramda": "^0.26.1",
+    "ramda": "^0.28.0",
     "redent": "^2.0.0"
   },
   "devDependencies": {

--- a/src/to-be-disabled.js
+++ b/src/to-be-disabled.js
@@ -1,4 +1,9 @@
-import { compose, defaultTo, includes, path, propEq, anyPass } from 'ramda';
+import compose from 'ramda/src/compose';
+import defaultTo from 'ramda/src/defaultTo';
+import includes from 'ramda/src/includes';
+import path from 'ramda/src/path';
+import propEq from 'ramda/src/propEq';
+import anyPass from 'ramda/src/anyPass';
 import { matcherHint } from 'jest-matcher-utils';
 
 import { checkReactElement, getType, printElement } from './utils';

--- a/src/to-be-empty.js
+++ b/src/to-be-empty.js
@@ -1,5 +1,8 @@
 import { matcherHint } from 'jest-matcher-utils';
-import { compose, defaultTo, isEmpty, not, path } from 'ramda';
+import compose from 'ramda/src/compose';
+import defaultTo from 'ramda/src/defaultTo';
+import path from 'ramda/src/path';
+import isEmpty from 'ramda/src/isEmpty';
 
 import { checkReactElement, printElement } from './utils';
 
@@ -7,11 +10,7 @@ export function toBeEmpty(element) {
   checkReactElement(element, toBeEmpty, this);
 
   return {
-    pass: compose(
-      isEmpty,
-      defaultTo({}),
-      path(['props', 'children']),
-    )(element),
+    pass: compose(isEmpty, defaultTo({}), path(['props', 'children']))(element),
     message: () => {
       return [
         matcherHint(`${this.isNot ? '.not' : ''}.toBeEmpty`, 'element', ''),

--- a/src/to-contain-element.js
+++ b/src/to-contain-element.js
@@ -1,4 +1,4 @@
-import { equals } from 'ramda';
+import equals from 'ramda/src/equals';
 import { matcherHint, RECEIVED_COLOR as receivedColor } from 'jest-matcher-utils';
 
 import { checkReactElement, printElement } from './utils';

--- a/src/to-have-prop.js
+++ b/src/to-have-prop.js
@@ -1,4 +1,4 @@
-import { equals } from 'ramda';
+import equals from 'ramda/src/equals';
 import { matcherHint, stringify, printExpected } from 'jest-matcher-utils';
 import { checkReactElement, getMessage } from './utils';
 

--- a/src/to-have-style.js
+++ b/src/to-have-style.js
@@ -1,8 +1,11 @@
 import { matcherHint } from 'jest-matcher-utils';
 import { diff } from 'jest-diff';
 import chalk from 'chalk';
-import { all, compose, flatten, mergeAll, toPairs } from 'ramda';
-
+import compose from 'ramda/src/compose';
+import all from 'ramda/src/all';
+import flatten from 'ramda/src/flatten';
+import mergeAll from 'ramda/src/mergeAll';
+import toPairs from 'ramda/src/toPairs';
 import { checkReactElement } from './utils';
 
 function isSubset(expected, received) {

--- a/src/to-have-text-content.js
+++ b/src/to-have-text-content.js
@@ -1,5 +1,11 @@
 import { matcherHint } from 'jest-matcher-utils';
-import { compose, defaultTo, is, join, map, path, filter } from 'ramda';
+import compose from 'ramda/src/compose';
+import defaultTo from 'ramda/src/defaultTo';
+import is from 'ramda/src/is';
+import join from 'ramda/src/join';
+import map from 'ramda/src/map';
+import path from 'ramda/src/path';
+import filter from 'ramda/src/filter';
 
 import { checkReactElement, getMessage, matches, normalize } from './utils';
 


### PR DESCRIPTION
Import directly the function to avoid jest creating a context for all the ramda utilities

<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**:

Import directly the ramda functions instead of the global index

**Why**:

Jest create a virtual machine for every imported file in order to provide a secure context. this has been reported in different jest issues 
- https://github.com/facebook/jest/issues/7963
- https://github.com/facebook/jest/issues/11234

profiling my project i see that 500ms is spent in everyfile due to the `setupFilesAfterEnv` https://jestjs.io/docs/configuration#setupfilesafterenv-array

<img width="1552" alt="Screenshot 2022-07-13 at 23 06 55" src="https://user-images.githubusercontent.com/6432326/178843148-625f8073-9027-402a-9339-6cdb7fb9318a.png">

and this is mainly because jest is creating a vm for each ramda function file

<img width="1552" alt="Screenshot 2022-07-13 at 23 07 22" src="https://user-images.githubusercontent.com/6432326/178843242-bf3b6b0a-360a-425a-9580-23f641a2d48e.png">


This has a tradeoff as it's a bit of incovenience for the mantainers but as this library is very linked to jest, i feel is interesting to pay this small code penalty to provide a faster performance for the consumers.

In my project we have over 200 test files and this change saved more than 30s on the CI testing time.

**How**:

Modify the import path to point directly to the function file.

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs](https://github.com/testing-library/jest-native/README.md)
- [x] Typescript definitions updated
- [X] Tests
- [X] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
