### PR TITLE
chore: update deps

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,7 +7,7 @@ jobs:
   main:
     strategy:
       matrix:
-        node: [12, 14]
+        node: [14, 16]
     runs-on: ubuntu-latest
     steps:
       - name: 🛑 Cancel Previous Runs

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,7 +7,7 @@ jobs:
   main:
     strategy:
       matrix:
-        node: [14, 16]
+        node: [14, 16, 18]
     runs-on: ubuntu-latest
     steps:
       - name: 🛑 Cancel Previous Runs

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "redent": "^2.0.0"
   },
   "devDependencies": {
-    "@babel/cli": "^7.13.6",
-    "@babel/core": "7.15.8",
+    "@babel/cli": "^7.18.10",
+    "@babel/core": "^7.18.10",
     "@babel/runtime": "^7.17.9",
     "@testing-library/react-native": "^11.0.0",
     "commitizen": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "husky": "^1.3.1",
     "jest": "^28.1.3",
     "metro-react-native-babel-preset": "^0.70.3",
-    "prettier": "^1.16.4",
+    "prettier": "^2.7.1",
     "pretty-quick": "^1.10.0",
     "react": "18.2.0",
     "react-native": "^0.69.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@babel/cli": "^7.13.6",
     "@babel/core": "7.15.8",
     "@babel/runtime": "^7.17.9",
-    "@testing-library/react-native": "^9.1.0",
+    "@testing-library/react-native": "^11.0.0",
     "commitizen": "^3.1.2",
     "cz-conventional-changelog": "^2.1.0",
     "husky": "^1.3.1",
@@ -47,9 +47,9 @@
     "metro-react-native-babel-preset": "^0.70.3",
     "prettier": "^1.16.4",
     "pretty-quick": "^1.10.0",
-    "react": "17.0.2",
-    "react-native": "^0.66.4",
-    "react-test-renderer": "^17.0.1",
+    "react": "18.2.0",
+    "react-native": "^0.69.3",
+    "react-test-renderer": "^18.2.0",
     "semantic-release": "^15.14.0"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "react-native"
   ],
   "dependencies": {
-    "chalk": "^2.4.1",
+    "chalk": "^4.1.2",
     "jest-diff": "^28.1.3",
     "jest-matcher-utils": "^28.1.3",
     "pretty-format": "^28.1.3",

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
   ],
   "dependencies": {
     "chalk": "^2.4.1",
-    "jest-diff": "^27.4.6",
-    "jest-matcher-utils": "^27.4.6",
-    "pretty-format": "^27.3.1",
+    "jest-diff": "^28.1.3",
+    "jest-matcher-utils": "^28.1.3",
+    "pretty-format": "^28.1.3",
     "ramda": "^0.28.0",
     "redent": "^2.0.0"
   },
@@ -43,7 +43,7 @@
     "commitizen": "^3.1.2",
     "cz-conventional-changelog": "^2.1.0",
     "husky": "^1.3.1",
-    "jest": "^27.0.6",
+    "jest": "^28.1.3",
     "metro-react-native-babel-preset": "^0.70.3",
     "prettier": "^1.16.4",
     "pretty-quick": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@babel/cli": "^7.18.10",
     "@babel/core": "^7.18.10",
-    "@babel/runtime": "^7.17.9",
+    "@babel/runtime": "^7.18.9",
     "@testing-library/react-native": "^11.0.0",
     "commitizen": "^3.1.2",
     "cz-conventional-changelog": "^2.1.0",
@@ -47,9 +47,9 @@
     "metro-react-native-babel-preset": "^0.70.3",
     "prettier": "^2.7.1",
     "pretty-quick": "^1.10.0",
-    "react": "18.2.0",
-    "react-native": "^0.69.3",
-    "react-test-renderer": "^18.2.0",
+    "react": "18.0.0",
+    "react-native": "^0.69.4",
+    "react-test-renderer": "18.0.0",
     "semantic-release": "^15.14.0"
   },
   "husky": {

--- a/src/to-contain-element.js
+++ b/src/to-contain-element.js
@@ -13,7 +13,7 @@ export function toContainElement(container, element) {
   let matches = [];
 
   if (element) {
-    matches = container.findAll(node => {
+    matches = container.findAll((node) => {
       const sameType = equals(node.type, element.type);
       const sameProps = equals(node.props, element.props);
 

--- a/src/to-have-style.js
+++ b/src/to-have-style.js
@@ -26,7 +26,7 @@ function mergeAllStyles(styles) {
 function printoutStyles(styles) {
   return Object.keys(styles)
     .sort()
-    .map(prop =>
+    .map((prop) =>
       Array.isArray(styles[prop])
         ? `${prop}: ${JSON.stringify(styles[prop], null, 2)};`
         : `${prop}: ${styles[prop]};`,
@@ -39,7 +39,7 @@ function printoutStyles(styles) {
  */
 function narrow(expected, received) {
   return Object.keys(received)
-    .filter(prop => expected[prop])
+    .filter((prop) => expected[prop])
     .reduce(
       (obj, prop) =>
         Object.assign(obj, {


### PR DESCRIPTION
**What**:

Update all primary deps to the newest versions.

Also needed to update node versions from 12 + 14, to 14 + 16 + 18, as RN 0.69 no longer supports Node 12:
```
error react-native@0.69.4: The engine "node" is incompatible with this module. Expected version ">=14". Got "12.22.1"
```

Also had to update `ramda/src/xxx` imports to `ramda/src/xxx.js`, as these first stopped working under node 16.

**Why**:

Time go by, we need to make sure we work with the current versions of React, React Native, RN Testing Library, Jest, etc

**How**:

Manually updated deps and verified that all tests pass.

**Checklist**:

- [x] Documentation added to the
      [docs](https://github.com/testing-library/jest-native/README.md)
- [x] Typescript definitions updated
- [x] Tests
- [x] Ready to be merged

Resolves #76, resolves #43,
