### PR TITLE
fix: update ramda imports

### DIFF
--- a/src/to-be-disabled.js
+++ b/src/to-be-disabled.js
@@ -1,9 +1,9 @@
-import compose from 'ramda/src/compose';
-import defaultTo from 'ramda/src/defaultTo';
-import includes from 'ramda/src/includes';
-import path from 'ramda/src/path';
-import propEq from 'ramda/src/propEq';
-import anyPass from 'ramda/src/anyPass';
+import compose from 'ramda/src/compose.js';
+import defaultTo from 'ramda/src/defaultTo.js';
+import includes from 'ramda/src/includes.js';
+import path from 'ramda/src/path.js';
+import propEq from 'ramda/src/propEq.js';
+import anyPass from 'ramda/src/anyPass.js';
 import { matcherHint } from 'jest-matcher-utils';
 
 import { checkReactElement, getType, printElement } from './utils';

--- a/src/to-be-empty.js
+++ b/src/to-be-empty.js
@@ -1,8 +1,8 @@
 import { matcherHint } from 'jest-matcher-utils';
-import compose from 'ramda/src/compose';
-import defaultTo from 'ramda/src/defaultTo';
-import path from 'ramda/src/path';
-import isEmpty from 'ramda/src/isEmpty';
+import compose from 'ramda/src/compose.js';
+import defaultTo from 'ramda/src/defaultTo.js';
+import path from 'ramda/src/path.js';
+import isEmpty from 'ramda/src/isEmpty.js';
 
 import { checkReactElement, printElement } from './utils';
 

--- a/src/to-contain-element.js
+++ b/src/to-contain-element.js
@@ -1,4 +1,4 @@
-import equals from 'ramda/src/equals';
+import equals from 'ramda/src/equals.js';
 import { matcherHint, RECEIVED_COLOR as receivedColor } from 'jest-matcher-utils';
 
 import { checkReactElement, printElement } from './utils';

--- a/src/to-have-prop.js
+++ b/src/to-have-prop.js
@@ -1,4 +1,4 @@
-import equals from 'ramda/src/equals';
+import equals from 'ramda/src/equals.js';
 import { matcherHint, stringify, printExpected } from 'jest-matcher-utils';
 import { checkReactElement, getMessage } from './utils';
 

--- a/src/to-have-style.js
+++ b/src/to-have-style.js
@@ -1,11 +1,11 @@
 import { matcherHint } from 'jest-matcher-utils';
 import { diff } from 'jest-diff';
 import chalk from 'chalk';
-import compose from 'ramda/src/compose';
-import all from 'ramda/src/all';
-import flatten from 'ramda/src/flatten';
-import mergeAll from 'ramda/src/mergeAll';
-import toPairs from 'ramda/src/toPairs';
+import compose from 'ramda/src/compose.js';
+import all from 'ramda/src/all.js';
+import flatten from 'ramda/src/flatten.js';
+import mergeAll from 'ramda/src/mergeAll.js';
+import toPairs from 'ramda/src/toPairs.js';
 import { checkReactElement } from './utils';
 
 function isSubset(expected, received) {


### PR DESCRIPTION
**What**:

Importing Jest Native in projects based on Node 14+ results in following error:

```
    ENOENT: no such file or directory, open '/Users/maciej/Dev/react-native-testing-library/examples/basic/node_modules/ramda/src/compose'

      at Runtime.readFile (node_modules/jest-runtime/build/index.js:2574:21)
      at Object.<anonymous> (node_modules/@testing-library/jest-native/dist/to-be-disabled.js:9:39)
```

**Why**:

Under node 14 the `.js` file extensions seems necessary in case of Ramda. Probably due to some technicalities of how Ramda export these. Note that Ramda does not seem maintained lately.

**How**:

App '.js' file extension to Ramda imports

**Checklist**:

- [x] Documentation added to the
      [docs](https://github.com/testing-library/jest-native/README.md)
- [x] Typescript definitions updated
- [x] Tests
- [x] Ready to be merged <!-- In your opinion -->
