### PR TITLE
fix: revert tweaked ramda imports

### DIFF
--- a/src/to-be-disabled.js
+++ b/src/to-be-disabled.js
@@ -1,11 +1,5 @@
-import compose from 'ramda/src/compose.js';
-import defaultTo from 'ramda/src/defaultTo.js';
-import includes from 'ramda/src/includes.js';
-import path from 'ramda/src/path.js';
-import propEq from 'ramda/src/propEq.js';
-import anyPass from 'ramda/src/anyPass.js';
 import { matcherHint } from 'jest-matcher-utils';
-
+import { compose, defaultTo, includes, path, propEq, anyPass } from 'ramda';
 import { checkReactElement, getType, printElement } from './utils';
 
 // Elements that support 'disabled'

--- a/src/to-be-empty.js
+++ b/src/to-be-empty.js
@@ -1,9 +1,5 @@
 import { matcherHint } from 'jest-matcher-utils';
-import compose from 'ramda/src/compose.js';
-import defaultTo from 'ramda/src/defaultTo.js';
-import path from 'ramda/src/path.js';
-import isEmpty from 'ramda/src/isEmpty.js';
-
+import { compose, defaultTo, path, isEmpty } from 'ramda';
 import { checkReactElement, printElement } from './utils';
 
 export function toBeEmpty(element) {

--- a/src/to-contain-element.js
+++ b/src/to-contain-element.js
@@ -1,6 +1,5 @@
-import equals from 'ramda/src/equals.js';
 import { matcherHint, RECEIVED_COLOR as receivedColor } from 'jest-matcher-utils';
-
+import { equals } from 'ramda';
 import { checkReactElement, printElement } from './utils';
 
 export function toContainElement(container, element) {

--- a/src/to-have-prop.js
+++ b/src/to-have-prop.js
@@ -1,5 +1,5 @@
-import equals from 'ramda/src/equals.js';
 import { matcherHint, stringify, printExpected } from 'jest-matcher-utils';
+import { equals } from 'ramda';
 import { checkReactElement, getMessage } from './utils';
 
 function printAttribute(name, value) {

--- a/src/to-have-style.js
+++ b/src/to-have-style.js
@@ -1,11 +1,7 @@
 import { matcherHint } from 'jest-matcher-utils';
 import { diff } from 'jest-diff';
 import chalk from 'chalk';
-import compose from 'ramda/src/compose.js';
-import all from 'ramda/src/all.js';
-import flatten from 'ramda/src/flatten.js';
-import mergeAll from 'ramda/src/mergeAll.js';
-import toPairs from 'ramda/src/toPairs.js';
+import { all, compose, flatten, mergeAll, toPairs } from 'ramda';
 import { checkReactElement } from './utils';
 
 function isSubset(expected, received) {


### PR DESCRIPTION
**What**:

Tweaking of Ramda imports in #82 has caused issues for some users. This PR is reverting that change.

**Why**:

User complained that Ramda import from Jest Native is failing with following error:
![image](https://user-images.githubusercontent.com/6368606/183898784-71788a51-2fea-4c4a-954b-4ccc0b892272.png)

**How**:

Replace imports from `ramda/src/xxx.js` with `{ xxx } from 'ramda';

**Checklist**:

- [x] Documentation added to the
      [docs](https://github.com/testing-library/jest-native/README.md)
- [x] Typescript definitions updated
- [x] Tests
- [x] Ready to be merged
