### PR TITLE
refactor: remove `ramda` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "jest-diff": "^28.1.3",
     "jest-matcher-utils": "^28.1.3",
     "pretty-format": "^28.1.3",
-    "ramda": "^0.28.0",
     "redent": "^2.0.0"
   },
   "devDependencies": {

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -38,6 +38,7 @@ test('isEmpty', () => {
   expect(isEmpty({})).toEqual(true);
   expect(isEmpty({ x: 0 })).toEqual(false);
   expect(isEmpty(0)).toEqual(true);
+  expect(isEmpty(1)).toEqual(false);
   expect(isEmpty(NaN)).toEqual(true);
   expect(isEmpty([''])).toEqual(false);
 });

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -1,4 +1,4 @@
-import { checkReactElement } from '../utils';
+import { checkReactElement, isEmpty, mergeAll } from '../utils';
 
 describe('checkReactElement', () => {
   test('it does not throw an error for valid native primitives', () => {
@@ -18,4 +18,26 @@ describe('checkReactElement', () => {
       checkReactElement({ type: 'Button' }, () => {});
     }).toThrow();
   });
+});
+
+test('mergeAll', () => {
+  expect(mergeAll([{ foo: 1 }, { bar: 2 }, { baz: 3 }])).toEqual({ foo: 1, bar: 2, baz: 3 });
+  expect(mergeAll([{ foo: 1 }, { foo: 2 }, { bar: 2 }])).toEqual({ foo: 2, bar: 2 });
+  expect(mergeAll([null, { foo: 1 }, { foo: 2 }, { bar: 2 }])).toEqual({ foo: 2, bar: 2 });
+  expect(mergeAll([{ foo: 1 }, { foo: 2 }, { bar: 2 }, undefined])).toEqual({ foo: 2, bar: 2 });
+  expect(mergeAll([{ foo: 1 }, { foo: 2 }, null, { bar: 2 }])).toEqual({ foo: 2, bar: 2 });
+});
+
+test('isEmpty', () => {
+  expect(isEmpty(null)).toEqual(true);
+  expect(isEmpty(undefined)).toEqual(true);
+  expect(isEmpty('')).toEqual(true);
+  expect(isEmpty(' ')).toEqual(false);
+  expect(isEmpty([])).toEqual(true);
+  expect(isEmpty([[]])).toEqual(false);
+  expect(isEmpty({})).toEqual(true);
+  expect(isEmpty({ x: 0 })).toEqual(false);
+  expect(isEmpty(0)).toEqual(true);
+  expect(isEmpty(NaN)).toEqual(true);
+  expect(isEmpty([''])).toEqual(false);
 });

--- a/src/to-be-disabled.js
+++ b/src/to-be-disabled.js
@@ -1,5 +1,4 @@
 import { matcherHint } from 'jest-matcher-utils';
-import { compose, defaultTo, includes, path, propEq, anyPass } from 'ramda';
 import { checkReactElement, getType, printElement } from './utils';
 
 // Elements that support 'disabled'

--- a/src/to-be-disabled.js
+++ b/src/to-be-disabled.js
@@ -22,20 +22,13 @@ function isElementDisabledByParent(parent) {
 }
 
 function isElementDisabled(element) {
-  const propDisabled = path(['props', 'disabled'], element);
-  const hasStatesDisabled = compose(
-    includes('disabled'),
-    defaultTo([]),
-    path(['props', 'accessibilityStates']),
-  );
-  const hasStateDisabled = compose(
-    propEq('disabled', true),
-    defaultTo({}),
-    path(['props', 'accessibilityState']),
-  );
-  const stateDisabled = anyPass([hasStatesDisabled, hasStateDisabled])(element);
+  if (!DISABLE_TYPES.includes(getType(element))) return false;
 
-  return DISABLE_TYPES.includes(getType(element)) && (Boolean(propDisabled) || stateDisabled);
+  return (
+    !!element?.props?.disabled ||
+    !!element?.props?.accessibilityState?.disabled ||
+    !!element?.props?.accessibilityStates?.includes('disabled')
+  );
 }
 
 function isAncestorDisabled(element) {

--- a/src/to-be-empty.js
+++ b/src/to-be-empty.js
@@ -1,12 +1,11 @@
 import { matcherHint } from 'jest-matcher-utils';
-import { compose, defaultTo, path, isEmpty } from 'ramda';
-import { checkReactElement, printElement } from './utils';
+import { checkReactElement, isEmpty, printElement } from './utils';
 
 export function toBeEmpty(element) {
   checkReactElement(element, toBeEmpty, this);
 
   return {
-    pass: compose(isEmpty, defaultTo({}), path(['props', 'children']))(element),
+    pass: isEmpty(element?.props?.children),
     message: () => {
       return [
         matcherHint(`${this.isNot ? '.not' : ''}.toBeEmpty`, 'element', ''),

--- a/src/to-contain-element.js
+++ b/src/to-contain-element.js
@@ -1,5 +1,4 @@
 import { matcherHint, RECEIVED_COLOR as receivedColor } from 'jest-matcher-utils';
-import { equals } from 'ramda';
 import { checkReactElement, printElement } from './utils';
 
 export function toContainElement(container, element) {

--- a/src/to-contain-element.js
+++ b/src/to-contain-element.js
@@ -13,10 +13,7 @@ export function toContainElement(container, element) {
 
   if (element) {
     matches = container.findAll((node) => {
-      const sameType = equals(node.type, element.type);
-      const sameProps = equals(node.props, element.props);
-
-      return sameType && sameProps;
+      return node.type === element.type && this.equals(node.props, element.props);
     });
   }
 

--- a/src/to-have-prop.js
+++ b/src/to-have-prop.js
@@ -1,5 +1,4 @@
 import { matcherHint, stringify, printExpected } from 'jest-matcher-utils';
-import { equals } from 'ramda';
 import { checkReactElement, getMessage } from './utils';
 
 function printAttribute(name, value) {
@@ -21,7 +20,7 @@ export function toHaveProp(element, name, expectedValue) {
   const hasProp = name in element.props;
 
   return {
-    pass: isDefined ? hasProp && equals(prop, expectedValue) : hasProp,
+    pass: isDefined ? hasProp && this.equals(prop, expectedValue) : hasProp,
     message: () => {
       const to = this.isNot ? 'not to' : 'to';
 

--- a/src/to-have-style.js
+++ b/src/to-have-style.js
@@ -1,22 +1,18 @@
 import { matcherHint } from 'jest-matcher-utils';
 import { diff } from 'jest-diff';
 import chalk from 'chalk';
-import { all, compose, flatten, mergeAll, toPairs } from 'ramda';
-import { checkReactElement } from './utils';
+import { checkReactElement, mergeAll } from './utils';
 
 function isSubset(expected, received) {
-  return compose(
-    all(([prop, value]) =>
-      Array.isArray(value)
-        ? isSubset(mergeAll(value), mergeAll(received[prop]))
-        : received[prop] === value,
-    ),
-    toPairs,
-  )(expected);
+  return Object.entries(expected).every(([prop, value]) =>
+    Array.isArray(value)
+      ? isSubset(mergeAll(value), mergeAll(received[prop]))
+      : received[prop] === value,
+  );
 }
 
 function mergeAllStyles(styles) {
-  return compose(mergeAll, flatten)(styles);
+  return mergeAll(styles.flat());
 }
 
 function printoutStyles(styles) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -91,6 +91,22 @@ function normalize(text) {
   return text.replace(/\s+/g, ' ').trim();
 }
 
+function isEmpty(value) {
+  if (!value) {
+    return true;
+  }
+
+  if (Array.isArray(value)) {
+    return value.length === 0;
+  }
+
+  if (typeof value === 'object') {
+    return Object.keys(value).length === 0;
+  }
+
+  return false;
+}
+
 export {
   ReactElementTypeError,
   checkReactElement,
@@ -98,5 +114,6 @@ export {
   getMessage,
   matches,
   normalize,
+  isEmpty,
   printElement,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -91,6 +91,10 @@ function normalize(text) {
   return text.replace(/\s+/g, ' ').trim();
 }
 
+function mergeAll(objects) {
+  return Object.assign({}, ...(objects ?? [{}]));
+}
+
 function isEmpty(value) {
   if (!value) {
     return true;
@@ -114,6 +118,7 @@ export {
   getMessage,
   matches,
   normalize,
+  mergeAll,
   isEmpty,
   printElement,
 };


### PR DESCRIPTION
**What**:

Remove Ramda dependency and replace with plain JS method where possible. 

Resolves #97 

**Why**:

Ramda has affected performance of Jest tests due to badly implemented treeshaking, and attempt #79  to optimise it using custom imports have caused issues for some users.

**How**:

Refactor to use plain JS:

Migration:
- [x] Migrate `toBeDisabled`
- [x] Migrate `toBeEmpty`
- [x] Migrate `toContainElement`
- [x] Migrate `toHaveProp`
- [x] Migrate `toHaveStyle`
- [x] Remove Ramda dep from `package.json`

**Checklist**:

- [x] Documentation added to the [docs](https://github.com/testing-library/jest-native/README.md)
- [x] Typescript definitions updated
- [x] Tests
- [x] Ready to be merged

<!-- feel free to add additional comments -->
