### PR TITLE
chore: eslint setup

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,13 +26,14 @@ jobs:
       - name: 📥 Download deps
         uses: bahmutov/npm-install@v1
         with:
+          useYarn: true
           useLockFile: false
 
       - name: ▶️ Run linter
-        run: npm run lint
+        run: yarn lint
 
       - name: ▶️ Run tests with coverage
-        run: npm run test:coverage
+        run: yarn test:coverage
 
       - name: ⬆️ Upload coverage report
         uses: codecov/codecov-action@v3
@@ -64,7 +65,7 @@ jobs:
           useLockFile: false
 
       - name: 🚀 Release
-        run: npm run semantic-release
+        run: yarn semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -28,7 +28,10 @@ jobs:
         with:
           useLockFile: false
 
-      - name: ▶️ Run validate script
+      - name: ▶️ Run linter
+        run: npm run lint
+
+      - name: ▶️ Run test script
         run: npm run test:coverage
 
       - name: ⬆️ Upload coverage report

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -31,8 +31,8 @@ jobs:
       - name: ▶️ Run linter
         run: npm run lint
 
-      - name: ▶️ Run test script
         run: npm run test:coverage
+      - name: ▶️ Run tests with coverage
 
       - name: ⬆️ Upload coverage report
         uses: codecov/codecov-action@v3

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -31,8 +31,8 @@ jobs:
       - name: ▶️ Run linter
         run: npm run lint
 
-        run: npm run test:coverage
       - name: ▶️ Run tests with coverage
+        run: npm run test:coverage
 
       - name: ⬆️ Upload coverage report
         uses: codecov/codecov-action@v3

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,10 +24,7 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: 📥 Download deps
-        uses: bahmutov/npm-install@v1
-        with:
-          useYarn: true
-          useLockFile: false
+        run: yarn install
 
       - name: ▶️ Run linter
         run: yarn lint

--- a/extend-expect.d.ts
+++ b/extend-expect.d.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { ReactTestInstance } from 'react-test-renderer';
+import type { ReactTestInstance } from 'react-test-renderer';
 
 declare global {
   namespace jest {

--- a/extend-expect.d.ts
+++ b/extend-expect.d.ts
@@ -1,7 +1,9 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { ReactTestInstance } from 'react-test-renderer';
 
 declare global {
   namespace jest {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     interface Matchers<R, T> {
       toBeDisabled(): R;
       toContainElement(element: ReactTestInstance | null): R;

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "^8.21.0",
     "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-promise": "^6.0.0",
     "jest": "^28.1.3",
     "metro-react-native-babel-preset": "^0.70.3",
     "prettier": "^2.7.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "commitizen": "^3.1.2",
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "^8.21.0",
-    "eslint-plugin-prettier": "^4.2.1",
     "husky": "^1.3.1",
     "jest": "^28.1.3",
     "metro-react-native-babel-preset": "^0.70.3",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "commit:all": "npm run commit:add && npm run commit",
     "readme:toc": "doctoc README.md --maxlevel 3 --title '## Table of Contents'",
     "test": "jest --colors",
+    "lint": "eslint \"**/*.js\"",
     "pretty-quick": "pretty-quick --staged",
     "prepublishOnly": "rm -rf dist; babel src --out-dir dist --ignore 'src/__tests__/*'",
     "semantic-release": "semantic-release",
@@ -38,10 +39,12 @@
     "@babel/cli": "^7.18.10",
     "@babel/core": "^7.18.10",
     "@babel/runtime": "^7.18.9",
+    "@callstack/eslint-config": "^12.0.2",
     "@testing-library/react-native": "^11.0.0",
     "commitizen": "^3.1.2",
     "cz-conventional-changelog": "^3.3.0",
-    "husky": "^1.3.1",
+    "eslint": "^8.21.0",
+    "eslint-plugin-prettier": "^4.2.1",
     "jest": "^28.1.3",
     "metro-react-native-babel-preset": "^0.70.3",
     "prettier": "^2.7.1",
@@ -51,11 +54,6 @@
     "react-test-renderer": "18.0.0",
     "semantic-release": "^19.0.3"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "npm run pretty-quick"
-    }
-  },
   "prettier": {
     "printWidth": 100,
     "singleQuote": true,
@@ -63,6 +61,25 @@
     "tabWidth": 2,
     "proseWrap": "always"
   },
+  "eslintConfig": {
+    "extends": "@callstack",
+    "env": {
+      "jest": true
+    },
+    "rules": {
+      "react-native/no-color-literals": "off",
+      "react-native/no-inline-styles": "off",
+      "react-native/no-raw-text": "off",
+      "react-native-a11y/has-valid-accessibility-descriptors": "off",
+      "react-native-a11y/has-accessibility-hint": "off",
+      "react-native-a11y/has-valid-accessibility-ignores-invert-colors": "off",
+      "react-native-a11y/has-valid-accessibility-value": "off"
+    }
+  },
+  "eslintIgnore": [
+    "node_modules/",
+    "lib/"
+  ],
   "release": {
     "branches": [
       "main"

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "^8.21.0",
     "eslint-plugin-prettier": "^4.2.1",
+    "husky": "^1.3.1",
     "jest": "^28.1.3",
     "metro-react-native-babel-preset": "^0.70.3",
     "prettier": "^2.7.1",
@@ -53,6 +54,11 @@
     "react-native": "^0.69.4",
     "react-test-renderer": "18.0.0",
     "semantic-release": "^19.0.3"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "npm run pretty-quick"
+    }
   },
   "prettier": {
     "printWidth": 100,

--- a/package.json
+++ b/package.json
@@ -54,6 +54,11 @@
     "react-test-renderer": "18.0.0",
     "semantic-release": "^19.0.3"
   },
+  "peerDependencies": {
+    "react": ">=16.0.0",
+    "react-native": ">=0.59",
+    "react-test-renderer": ">=16.0.0"
+  },
   "husky": {
     "hooks": {
       "pre-commit": "npm run pretty-quick"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "^8.21.0",
     "eslint-plugin-prettier": "^4.2.1",
-    "eslint-plugin-promise": "^6.0.0",
     "jest": "^28.1.3",
     "metro-react-native-babel-preset": "^0.70.3",
     "prettier": "^2.7.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "commit:all": "npm run commit:add && npm run commit",
     "readme:toc": "doctoc README.md --maxlevel 3 --title '## Table of Contents'",
     "test": "jest --colors",
-    "lint": "eslint \"**/*.js\"",
+    "lint": "eslint .",
     "pretty-quick": "pretty-quick --staged",
     "prepublishOnly": "rm -rf dist; babel src --out-dir dist --ignore 'src/__tests__/*'",
     "semantic-release": "semantic-release",

--- a/src/__tests__/to-contain-element.js
+++ b/src/__tests__/to-contain-element.js
@@ -16,6 +16,7 @@ const parent = queryByTestId('parent');
 const child = queryByTestId('child');
 const textElement = queryByTestId('text-element');
 const nonExistantElement = queryByTestId('not-exists');
+const fakeElement = undefined;
 
 test('.toContainElement positive test cases', () => {
   expect(grandparent).toContainElement(parent);

--- a/src/__tests__/to-have-prop.js
+++ b/src/__tests__/to-have-prop.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button, Text, View } from 'react-native';
 import { render } from '@testing-library/react-native';
 
-describe('.toHaveProp', () => {
+test('.toHaveProp', () => {
   const { queryByTestId } = render(
     <View accessibilityLabel={null} testID="view">
       <Text allowFontScaling={false} testID="text" editable={false}>

--- a/src/__tests__/to-have-prop.js
+++ b/src/__tests__/to-have-prop.js
@@ -32,7 +32,5 @@ test('.toHaveProp', () => {
     expect(queryByTestId('text')).toHaveProp('allowFontScaling', 'wrongValue'),
   ).toThrowError();
 
-  it('checks null values', () => {
-    expect(queryByTestId('view')).toHaveProp('accessibilityLabel', null);
-  });
+  expect(queryByTestId('view')).toHaveProp('accessibilityLabel', null);
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -35,7 +35,9 @@ class ReactElementTypeError extends Error {
     let withType = '';
     try {
       withType = printWithType('Received', received, printReceived);
-    } catch (e) {}
+    } catch (e) {
+      // Deliberately empty.
+    }
     /* istanbul ignore next */
     this.message = [
       matcherHint(`${context.isNot ? '.not' : ''}.${matcherFn.name}`, 'received', ''),


### PR DESCRIPTION
**What**:

Setup ESLint validation with reasonable rules. Fix remaining rule violations.

Also:
- switch to plain Yarn because of install issues with NPM & npm-install action (no noticable perf impact on CI runs)

**Why**:

Extra safety net on the CI for code quality assurance. 

**How**:

* Added eslint deps
* Set reasonable rules based on RNTL rules
* Added linter step to GH action

**Checklist**:

- [x] Documentation added to the [docs](https://github.com/testing-library/jest-native/README.md)
- [x] Typescript definitions updated
- [x] Tests
- [x] Ready to be merged