### PR TITLE
refactor: add toBeEmptyElement assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 - [Matchers](#matchers)
   - [`toBeDisabled`](#tobedisabled)
   - [`toBeEnabled`](#tobeenabled)
-  - [`toBeEmpty`](#tobeempty)
+  - [`toBeEmptyElement`](#tobeemptyelement)
   - [`toContainElement`](#tocontainelement)
   - [`toHaveProp`](#tohaveprop)
   - [`toHaveTextContent`](#tohavetextcontent)
@@ -98,9 +98,9 @@ Alternatively, you can selectively import only the matchers you intend to use, a
 `expect` yourself:
 
 ```javascript
-import { toBeEmpty, toHaveTextContent } from '@testing-library/jest-native';
+import { toBeEmptyElement, toHaveTextContent } from '@testing-library/jest-native';
 
-expect.extend({ toBeEmpty, toHaveTextContent });
+expect.extend({ toBeEmptyElement, toHaveTextContent });
 ```
 
 ## Matchers
@@ -160,10 +160,10 @@ expect(getByTestId('button')).toBeEnabled();
 expect(getByTestId('input')).toBeEnabled();
 ```
 
-### `toBeEmpty`
+### `toBeEmptyElement`
 
 ```javascript
-toBeEmpty();
+toBeEmptyElement();
 ```
 
 Check that the given element has no content.
@@ -173,7 +173,7 @@ Check that the given element has no content.
 ```javascript
 const { getByTestId } = render(<View testID="empty" />);
 
-expect(getByTestId('empty')).toBeEmpty();
+expect(getByTestId('empty')).toBeEmptyElement();
 ```
 
 ### `toContainElement`

--- a/src/__tests__/to-be-empty-element.js
+++ b/src/__tests__/to-be-empty-element.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { View } from 'react-native';
 import { render } from '@testing-library/react-native';
 
-test('.toBeEmpty', () => {
+test('.toBeEmptyElement', () => {
   const { queryByTestId } = render(
     <View testID="not-empty">
       <View testID="empty" />
@@ -14,17 +14,17 @@ test('.toBeEmpty', () => {
   const nonExistantElement = queryByTestId('not-exists');
   const fakeElement = { thisIsNot: 'an html element' };
 
-  expect(empty).toBeEmpty();
-  expect(notEmpty).not.toBeEmpty();
+  expect(empty).toBeEmptyElement();
+  expect(notEmpty).not.toBeEmptyElement();
 
   // negative test cases wrapped in throwError assertions for coverage.
-  expect(() => expect(empty).not.toBeEmpty()).toThrow();
+  expect(() => expect(empty).not.toBeEmptyElement()).toThrow();
 
-  expect(() => expect(notEmpty).toBeEmpty()).toThrow();
+  expect(() => expect(notEmpty).toBeEmptyElement()).toThrow();
 
-  expect(() => expect(fakeElement).toBeEmpty()).toThrow();
+  expect(() => expect(fakeElement).toBeEmptyElement()).toThrow();
 
   expect(() => {
-    expect(nonExistantElement).toBeEmpty();
+    expect(nonExistantElement).toBeEmptyElement();
   }).toThrow();
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import { toBeDisabled, toBeEnabled } from './to-be-disabled';
-import { toBeEmpty } from './to-be-empty';
+import { toBeEmptyElement } from './to-be-empty-element';
 import { toHaveProp } from './to-have-prop';
 import { toHaveTextContent } from './to-have-text-content';
 import { toContainElement } from './to-contain-element';
@@ -8,7 +8,7 @@ import { toHaveStyle } from './to-have-style';
 export {
   toBeDisabled,
   toContainElement,
-  toBeEmpty,
+  toBeEmptyElement,
   toHaveProp,
   toHaveTextContent,
   toBeEnabled,

--- a/src/to-be-empty-element.js
+++ b/src/to-be-empty-element.js
@@ -1,12 +1,8 @@
 import { matcherHint } from 'jest-matcher-utils';
 import { checkReactElement, isEmpty, printElement } from './utils';
 
-/**
- * @deprecated This function is deprecated. You should use `toBeEmptyElement`
- *
- * */
-export function toBeEmpty(element) {
-  checkReactElement(element, toBeEmpty, this);
+export function toBeEmptyElement(element) {
+  checkReactElement(element, toBeEmptyElement, this);
 
   return {
     pass: isEmpty(element?.props?.children),


### PR DESCRIPTION
<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**:

closes https://github.com/testing-library/jest-native/issues/102.

This PR consists in create a new assertion called `toBeEmptyElement` and make current assertion `toBeEmpty` deprecated.

**Why**:

Jest-Extended has an assertion named the same as jest-native's one:

-> https://github.com/jest-community/jest-extended#tobeempty
-> https://github.com/testing-library/jest-native#tobeempty

When both libs are used in the same project, the version of jest-extended overwrites the one from jest-native.

@testing-library/jest-dom has had the same problem https://github.com/testing-library/jest-dom/issues/216 and they renamed their matcher to toBeEmptyDOMElement .

**How**:

Just was created a new assertion called `toBeEmptyElement` that have the same behavior of current assertion `toBeEmpty`.

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs](https://github.com/testing-library/jest-native/README.md)
- [ ] Typescript definitions updated
- [x] Tests
- [ ] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
