### PR TITLE
fix: improve element formatting

### DIFF
--- a/src/__tests__/__snapshots__/to-be-visible.tsx.snap
+++ b/src/__tests__/__snapshots__/to-be-visible.tsx.snap
@@ -4,25 +4,21 @@ exports[`.toBeVisible throws an error when expectation is not matched 1`] = `
 "expect(element).not.toBeVisible()
 
 Received element is visible:
-  Object {
-  "props": Object {
-    "children": undefined,
-    "testID": "test",
-  },
-}"
+  <View
+    testID="test"
+  />"
 `;
 
 exports[`.toBeVisible throws an error when expectation is not matched 2`] = `
 "expect(element).toBeVisible()
 
 Received element is not visible:
-  Object {
-  "props": Object {
-    "children": undefined,
-    "style": Object {
-      "opacity": 0,
-    },
-    "testID": "test",
-  },
-}"
+  <View
+    style={
+      {
+        "opacity": 0,
+      }
+    }
+    testID="test"
+  />"
 `;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -78,6 +78,8 @@ function printElement(element: ReactTestInstance | null) {
   return redent(
     prettyFormat(
       {
+        // This prop is needed persuade the prettyFormat that the element is
+        // a ReactTestRendererJSON instance, so it is formatted as JSX.
         $$typeof: Symbol.for('react.test.json'),
         type: element.type,
         props: element.props,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -75,14 +75,22 @@ function printElement(element: ReactTestInstance | null) {
     return 'null';
   }
 
-  return `  ${prettyFormat(
-    { props: element.props },
-    {
-      plugins: [ReactTestComponent, ReactElement],
-      printFunctionName: false,
-      highlight: true,
-    },
-  )}`;
+  return redent(
+    prettyFormat(
+      {
+        $$typeof: Symbol.for('react.test.json'),
+        type: element.type,
+        props: element.props,
+      },
+      {
+        plugins: [ReactTestComponent, ReactElement],
+        printFunctionName: false,
+        printBasicPrototype: false,
+        highlight: true,
+      },
+    ),
+    2,
+  );
 }
 
 function display(value: unknown) {


### PR DESCRIPTION
**What**:

Improve element formatting in output messages:

Before:
```
Received element is visible:
  Object {
  "props": Object {
    "children": undefined,
    "testID": "test",
  },
}
```

After:
```
Received element is visible:
  <View
    testID="test"
  />
```

**Why**:

Improve readability for printed element

**How**:

Persuade ReactTestComponent plugin to pretty-format package that passed element is `ReactTestRendererJSON` instance, so that if formats it as JSX.

**Checklist**:

- [x] Documentation added to the
      [docs](https://github.com/testing-library/jest-native/README.md) N/A
- [x] Typescript definitions updated N/A
- [x] Tests
- [x] Ready to be merged 
