### PR TITLE
fix: Add missing StyleProp type in TS definition file

### DIFF
--- a/extend-expect.d.ts
+++ b/extend-expect.d.ts
@@ -1,4 +1,4 @@
-import type { ImageStyle, TextStyle, ViewStyle } from 'react-native';
+import type { ImageStyle, StyleProp, TextStyle, ViewStyle } from 'react-native';
 import type { ReactTestInstance } from 'react-test-renderer';
 
 declare global {


### PR DESCRIPTION
<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
`extend-expect.d.ts` is using `StyleProp` type, but this type is not imported. It causes TS error when library is using with other TypeScript projects.

**Why**:
To have error-free TS parser.

<!-- Why are these changes necessary? -->

**How**:
By updating TS definition file.
<!-- How were these changes implemented? -->

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs](https://github.com/testing-library/jest-native/README.md)
- [x] Typescript definitions updated
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
