### PR TITLE
fix: .toBeVisible error with Pressable function style

### DIFF
--- a/src/__tests__/component-tree.tsx
+++ b/src/__tests__/component-tree.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { View } from 'react-native';
+import { render } from '@testing-library/react-native';
+import { getParentElement } from '../component-tree';
+
+function MultipleHostChildren() {
+  return (
+    <>
+      <View testID="child1" />
+      <View testID="child2" />
+      <View testID="child3" />
+    </>
+  );
+}
+
+describe('getParentElement()', () => {
+  it('returns host parent for host component', () => {
+    const view = render(
+      <View testID="grandparent">
+        <View testID="parent">
+          <View testID="subject" />
+          <View testID="sibling" />
+        </View>
+      </View>,
+    );
+
+    const hostParent = getParentElement(view.getByTestId('subject'));
+    expect(hostParent).toBe(view.getByTestId('parent'));
+
+    const hostGrandparent = getParentElement(hostParent);
+    expect(hostGrandparent).toBe(view.getByTestId('grandparent'));
+
+    expect(getParentElement(hostGrandparent)).toBe(null);
+  });
+
+  it('returns host parent for null', () => {
+    expect(getParentElement(null)).toBe(null);
+  });
+
+  it('returns host parent for composite component', () => {
+    const view = render(
+      <View testID="parent">
+        <MultipleHostChildren />
+        <View testID="subject" />
+      </View>,
+    );
+
+    const compositeComponent = view.UNSAFE_getByType(MultipleHostChildren);
+    const hostParent = getParentElement(compositeComponent);
+    expect(hostParent).toBe(view.getByTestId('parent'));
+  });
+});

--- a/src/__tests__/to-be-visible.tsx
+++ b/src/__tests__/to-be-visible.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Modal, Pressable, View } from 'react-native';
+import { View, Pressable, Modal } from 'react-native';
 import { render } from '@testing-library/react-native';
 
 describe('.toBeVisible', () => {
@@ -134,7 +134,9 @@ describe('.toBeVisible', () => {
   });
 
   it('handles Pressable with function style prop', () => {
-    const { getByTestId } = render(<Pressable testID="test" style={() => ({})} />);
+    const { getByTestId } = render(
+      <Pressable testID="test" style={() => ({ backgroundColor: 'blue' })} />,
+    );
     expect(getByTestId('test')).toBeVisible();
   });
 });

--- a/src/__tests__/to-be-visible.tsx
+++ b/src/__tests__/to-be-visible.tsx
@@ -120,12 +120,21 @@ describe('.toBeVisible', () => {
     expect(getByTestId('test')).not.toBeVisible();
   });
 
-  it('handles non-React elements', () => {
+  test('handles null elements', () => {
+    expect(() => expect(null).toBeVisible()).toThrowErrorMatchingInlineSnapshot(`
+      "expect(received).toBeVisible()
+
+      received value must be a React Element.
+      Received has value: null"
+    `);
+  });
+
+  test('handles non-React elements', () => {
     expect(() => expect({ name: 'Non-React element' }).not.toBeVisible()).toThrow();
     expect(() => expect(true).not.toBeVisible()).toThrow();
   });
 
-  it('throws an error when expectation is not matched', () => {
+  test('throws an error when expectation is not matched', () => {
     const { getByTestId, update } = render(<View testID="test" />);
     expect(() => expect(getByTestId('test')).not.toBeVisible()).toThrowErrorMatchingSnapshot();
 
@@ -133,7 +142,7 @@ describe('.toBeVisible', () => {
     expect(() => expect(getByTestId('test')).toBeVisible()).toThrowErrorMatchingSnapshot();
   });
 
-  it('handles Pressable with function style prop', () => {
+  test('handles Pressable with function style prop', () => {
     const { getByTestId } = render(
       <Pressable testID="test" style={() => ({ backgroundColor: 'blue' })} />,
     );

--- a/src/__tests__/to-be-visible.tsx
+++ b/src/__tests__/to-be-visible.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Modal, View } from 'react-native';
+import { Modal, Pressable, View } from 'react-native';
 import { render } from '@testing-library/react-native';
 
 describe('.toBeVisible', () => {
@@ -131,5 +131,10 @@ describe('.toBeVisible', () => {
 
     update(<View testID="test" style={{ opacity: 0 }} />);
     expect(() => expect(getByTestId('test')).toBeVisible()).toThrowErrorMatchingSnapshot();
+  });
+
+  it('handles Pressable with function style prop', () => {
+    const { getByTestId } = render(<Pressable testID="test" style={() => ({})} />);
+    expect(getByTestId('test')).toBeVisible();
   });
 });

--- a/src/__tests__/to-have-style.tsx
+++ b/src/__tests__/to-have-style.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet, View, Text } from 'react-native';
+import { StyleSheet, View, Text, Pressable } from 'react-native';
 import { render } from '@testing-library/react-native';
 
 describe('.toHaveStyle', () => {
@@ -89,5 +89,12 @@ describe('.toHaveStyle', () => {
     expect(() =>
       expect(container).toHaveStyle({ transform: [{ scale: 1 }] }),
     ).toThrowErrorMatchingSnapshot();
+  });
+
+  test('handles Pressable with function style prop', () => {
+    const { getByTestId } = render(
+      <Pressable testID="test" style={() => ({ backgroundColor: 'blue' })} />,
+    );
+    expect(getByTestId('test')).toHaveStyle({ backgroundColor: 'blue' });
   });
 });

--- a/src/component-tree.ts
+++ b/src/component-tree.ts
@@ -1,0 +1,37 @@
+import type React from 'react';
+import type { ReactTestInstance } from 'react-test-renderer';
+
+/**
+ * Checks if the given element is a host element.
+ * @param element The element to check.
+ */
+export function isHostElement(element?: ReactTestInstance | null): boolean {
+  return typeof element?.type === 'string';
+}
+
+/**
+ * Returns first host ancestor for given element or first ancestor of one of
+ * passed component types.
+ *
+ * @param element The element start traversing from.
+ * @param componentTypes Additional component types to match.
+ */
+export function getParentElement(
+  element: ReactTestInstance | null,
+  componentTypes: React.ElementType[] = [],
+): ReactTestInstance | null {
+  if (element == null) {
+    return null;
+  }
+
+  let current = element.parent;
+  while (current) {
+    if (isHostElement(current) || componentTypes.includes(current.type)) {
+      return current;
+    }
+
+    current = current.parent;
+  }
+
+  return null;
+}

--- a/src/to-be-visible.ts
+++ b/src/to-be-visible.ts
@@ -5,7 +5,7 @@ import type { ReactTestInstance } from 'react-test-renderer';
 import { checkReactElement, printElement } from './utils';
 import { getParentElement } from './component-tree';
 
-function isVisibleToStyle(element: ReactTestInstance) {
+function isVisibleForStyles(element: ReactTestInstance) {
   const style = element.props.style || {};
   const { display, opacity } = StyleSheet.flatten(style);
   return display !== 'none' && opacity !== 0;
@@ -30,7 +30,7 @@ function isElementVisible(element: ReactTestInstance | null): boolean {
   let current: ReactTestInstance | null = element;
   while (current) {
     const isVisible =
-      isVisibleToStyle(current) && isVisibleForAccessibility(current) && isModalVisible(current);
+      isVisibleForStyles(current) && isVisibleForAccessibility(current) && isModalVisible(current);
     if (!isVisible) {
       return false;
     }

--- a/src/to-be-visible.ts
+++ b/src/to-be-visible.ts
@@ -22,16 +22,14 @@ function isModalVisible(element: ReactTestInstance) {
   return element.type !== Modal || element.props.visible !== false;
 }
 
-function isElementVisible(element: ReactTestInstance | null): boolean {
-  if (element == null) {
-    return false;
-  }
-
+function isElementVisible(element: ReactTestInstance): boolean {
   let current: ReactTestInstance | null = element;
   while (current) {
-    const isVisible =
-      isVisibleForStyles(current) && isVisibleForAccessibility(current) && isModalVisible(current);
-    if (!isVisible) {
+    if (
+      !isVisibleForStyles(current) ||
+      !isVisibleForAccessibility(current) ||
+      !isModalVisible(current)
+    ) {
       return false;
     }
 

--- a/src/to-be-visible.ts
+++ b/src/to-be-visible.ts
@@ -2,11 +2,14 @@ import { Modal, StyleSheet } from 'react-native';
 import { matcherHint } from 'jest-matcher-utils';
 import type { ReactTestInstance } from 'react-test-renderer';
 
-import { checkReactElement, printElement } from './utils';
+import { checkReactElement, getType, printElement } from './utils';
 
 function isStyleVisible(element: ReactTestInstance) {
   const style = element.props.style || {};
-  const { display, opacity } = StyleSheet.flatten(style);
+  const isStyleFunction = getType(element) === 'Pressable' && typeof style === 'function';
+  const { display, opacity } = StyleSheet.flatten(
+    isStyleFunction ? style({ pressed: false }) : style,
+  );
   return display !== 'none' && opacity !== 0;
 }
 


### PR DESCRIPTION
<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**:

Fixes https://github.com/testing-library/jest-native/issues/133

To fix an error when `.toBeVisible` is used on a Pressable using a function for the `style` prop

**Why**:

Using a function is a documented use case ([doc](https://reactnative.dev/docs/pressable#style)) and so it should be supported.

**How**:

By adding a check if the style prop is a function and calling it with `{ pressed: false }` as a default value.

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the [docs](https://github.com/testing-library/jest-native/README.md) (N/A)
- [x] Typescript definitions updated (N/A)
- [x] Tests
- [x] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
