### PR TITLE
fix: support TextInput editable={false} prop check in isEnabled/isDisabled matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,11 @@ toBeDisabled();
 
 Check whether or not an element is disabled from a user perspective.
 
-This matcher will check if the element or its parent has a `disabled` prop, or if it has
-`accessibilityState={{disabled: true}}.
+This matcher will check if the element or its parent has any of thoses props value:
+
+- `disabled={true}`
+- `accessibilityState={{disabled: true}}`
+- `editable={false}`
 
 It also works with `accessibilityStates={['disabled']}` for now. However, this prop is deprecated in
 React Native [0.62](https://reactnative.dev/blog/2020/03/26/version-0.62#breaking-changes)

--- a/README.md
+++ b/README.md
@@ -119,11 +119,11 @@ toBeDisabled();
 
 Check whether or not an element is disabled from a user perspective.
 
-This matcher will check if the element or its parent has any of thoses props value:
+This matcher will check if the element or its parent has any of those props :
 
 - `disabled={true}`
 - `accessibilityState={{disabled: true}}`
-- `editable={false}`
+- `editable={false}` for `TextInput` only
 
 It also works with `accessibilityStates={['disabled']}` for now. However, this prop is deprecated in
 React Native [0.62](https://reactnative.dev/blog/2020/03/26/version-0.62#breaking-changes)

--- a/README.md
+++ b/README.md
@@ -119,10 +119,9 @@ toBeDisabled();
 
 Check whether or not an element is disabled from a user perspective.
 
-This matcher will check if the element or its parent has any of those props :
-
-- `disabled={true}`
-- `accessibilityState={{disabled: true}}`
+This matcher will check if the element or its parent has any of the following props :
+- `disabled`
+- `accessibilityState={{ disabled: true }}`
 - `editable={false}` (for `TextInput` only)
 
 It also works with `accessibilityStates={['disabled']}` for now. However, this prop is deprecated in

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ This matcher will check if the element or its parent has any of those props :
 
 - `disabled={true}`
 - `accessibilityState={{disabled: true}}`
-- `editable={false}` for `TextInput` only
+- `editable={false}` (for `TextInput` only)
 
 It also works with `accessibilityStates={['disabled']}` for now. However, this prop is deprecated in
 React Native [0.62](https://reactnative.dev/blog/2020/03/26/version-0.62#breaking-changes)

--- a/src/__tests__/to-be-disabled.tsx
+++ b/src/__tests__/to-be-disabled.tsx
@@ -110,7 +110,7 @@ describe('.toBeEnabled', () => {
 describe('for .toBeEnabled/Disabled Button', () => {
   test('handles disabled prop for button', () => {
     const { queryByTestId } = render(
-      <View testID="view">
+      <View>
         <Button testID="enabled" title="enabled" />
         <Button disabled testID="disabled" title="disabled" />
       </View>,
@@ -122,7 +122,7 @@ describe('for .toBeEnabled/Disabled Button', () => {
 
   test('handles button a11y state', () => {
     const { queryByTestId } = render(
-      <View testID="view">
+      <View>
         <Button accessibilityState={{ disabled: false }} testID="enabled" title="enabled" />
         <Button accessibilityState={{ disabled: true }} testID="disabled" title="disabled" />
       </View>,
@@ -134,7 +134,7 @@ describe('for .toBeEnabled/Disabled Button', () => {
 
   test('Errors when matcher misses', () => {
     const { queryByTestId, queryByText } = render(
-      <View testID="view">
+      <View>
         <Button testID="enabled" title="enabled" />
         <Button disabled testID="disabled" title="disabled" />
       </View>,

--- a/src/__tests__/to-be-disabled.tsx
+++ b/src/__tests__/to-be-disabled.tsx
@@ -51,15 +51,17 @@ describe('.toBeDisabled', () => {
   });
 
   test('handle editable prop for TextInput', () => {
-    const { queryByTestId } = render(
+    const { getByTestId } = render(
       <View>
         <TextInput testID="disabled" editable={false} />
+        <TextInput testID="enabled-by-default" />
         <TextInput testID="enabled" editable />
       </View>,
     );
 
-    expect(queryByTestId('disabled')).toBeDisabled();
-    expect(queryByTestId('enabled')).not.toBeDisabled();
+    expect(getByTestId('disabled')).toBeDisabled();
+    expect(getByTestId('enabled-by-default')).not.toBeDisabled();
+    expect(getByTestId('enabled')).not.toBeDisabled();
   });
 });
 
@@ -93,7 +95,7 @@ describe('.toBeEnabled', () => {
   });
 
   test('handle editable prop for TextInput', () => {
-    const { queryByTestId } = render(
+    const { getByTestId } = render(
       <View>
         <TextInput testID="enabled-by-default" />
         <TextInput testID="enabled" editable />
@@ -101,9 +103,9 @@ describe('.toBeEnabled', () => {
       </View>,
     );
 
-    expect(queryByTestId('enabled-by-default')).toBeEnabled();
-    expect(queryByTestId('enabled')).toBeEnabled();
-    expect(queryByTestId('disabled')).not.toBeEnabled();
+    expect(getByTestId('enabled-by-default')).toBeEnabled();
+    expect(getByTestId('enabled')).toBeEnabled();
+    expect(getByTestId('disabled')).not.toBeEnabled();
   });
 });
 

--- a/src/__tests__/to-be-disabled.tsx
+++ b/src/__tests__/to-be-disabled.tsx
@@ -49,6 +49,18 @@ describe('.toBeDisabled', () => {
       expect(() => expect(queryByTestId(name)).not.toBeDisabled()).toThrow();
     });
   });
+
+  test('handle editable prop for TextInput when false', () => {
+    const { queryByTestId } = render(
+      <View testID="view">
+        <TextInput testID="disabled" editable={false} />
+        <TextInput testID="enabled" editable />
+      </View>,
+    );
+
+    expect(queryByTestId('disabled')).toBeDisabled();
+    expect(queryByTestId('enabled')).not.toBeDisabled();
+  });
 });
 
 describe('.toBeEnabled', () => {
@@ -78,6 +90,20 @@ describe('.toBeEnabled', () => {
       expect(queryByTestId(name)).toBeEnabled();
       expect(() => expect(queryByTestId(name)).not.toBeEnabled()).toThrow();
     });
+  });
+
+  test('handle editable prop for TextInput when true', () => {
+    const { queryByTestId } = render(
+      <View testID="view">
+        <TextInput testID="enabled-by-default" />
+        <TextInput testID="enabled" editable />
+        <TextInput testID="disabled" editable={false} />
+      </View>,
+    );
+
+    expect(queryByTestId('enabled-by-default')).toBeEnabled();
+    expect(queryByTestId('enabled')).toBeEnabled();
+    expect(queryByTestId('disabled')).not.toBeEnabled();
   });
 });
 

--- a/src/__tests__/to-be-disabled.tsx
+++ b/src/__tests__/to-be-disabled.tsx
@@ -50,9 +50,9 @@ describe('.toBeDisabled', () => {
     });
   });
 
-  test('handle editable prop for TextInput when false', () => {
+  test('handle editable prop for TextInput', () => {
     const { queryByTestId } = render(
-      <View testID="view">
+      <View>
         <TextInput testID="disabled" editable={false} />
         <TextInput testID="enabled" editable />
       </View>,
@@ -92,9 +92,9 @@ describe('.toBeEnabled', () => {
     });
   });
 
-  test('handle editable prop for TextInput when true', () => {
+  test('handle editable prop for TextInput', () => {
     const { queryByTestId } = render(
-      <View testID="view">
+      <View>
         <TextInput testID="enabled-by-default" />
         <TextInput testID="enabled" editable />
         <TextInput testID="disabled" editable={false} />

--- a/src/__tests__/to-be-disabled.tsx
+++ b/src/__tests__/to-be-disabled.tsx
@@ -51,17 +51,23 @@ describe('.toBeDisabled', () => {
   });
 
   test('handle editable prop for TextInput', () => {
-    const { getByTestId } = render(
+    const { getByTestId, getByPlaceholderText } = render(
       <View>
-        <TextInput testID="disabled" editable={false} />
-        <TextInput testID="enabled-by-default" />
-        <TextInput testID="enabled" editable />
+        <TextInput testID="disabled" placeholder="disabled" editable={false} />
+        <TextInput testID="enabled-by-default" placeholder="enabled-by-default" />
+        <TextInput testID="enabled" placeholder="enabled" editable />
       </View>,
     );
 
+    // Check host TextInput
     expect(getByTestId('disabled')).toBeDisabled();
     expect(getByTestId('enabled-by-default')).not.toBeDisabled();
     expect(getByTestId('enabled')).not.toBeDisabled();
+
+    // Check composite TextInput
+    expect(getByPlaceholderText('disabled')).toBeDisabled();
+    expect(getByPlaceholderText('enabled-by-default')).not.toBeDisabled();
+    expect(getByPlaceholderText('enabled')).not.toBeDisabled();
   });
 });
 
@@ -95,17 +101,23 @@ describe('.toBeEnabled', () => {
   });
 
   test('handle editable prop for TextInput', () => {
-    const { getByTestId } = render(
+    const { getByTestId, getByPlaceholderText } = render(
       <View>
-        <TextInput testID="enabled-by-default" />
-        <TextInput testID="enabled" editable />
-        <TextInput testID="disabled" editable={false} />
+        <TextInput testID="enabled-by-default" placeholder="enabled-by-default" />
+        <TextInput testID="enabled" placeholder="enabled" editable />
+        <TextInput testID="disabled" placeholder="disabled" editable={false} />
       </View>,
     );
 
+    // Check host TextInput
     expect(getByTestId('enabled-by-default')).toBeEnabled();
     expect(getByTestId('enabled')).toBeEnabled();
     expect(getByTestId('disabled')).not.toBeEnabled();
+
+    // Check composite TextInput
+    expect(getByPlaceholderText('enabled-by-default')).toBeEnabled();
+    expect(getByPlaceholderText('enabled')).toBeEnabled();
+    expect(getByPlaceholderText('disabled')).not.toBeEnabled();
   });
 });
 

--- a/src/to-be-disabled.ts
+++ b/src/to-be-disabled.ts
@@ -19,12 +19,14 @@ const DISABLE_TYPES = [
 
 function isElementDisabled(element: ReactTestInstance) {
   if (!DISABLE_TYPES.includes(getType(element))) return false;
+  if (getType(element) === 'TextInput' && element?.props?.editable === false) {
+    return true;
+  }
 
   return (
     !!element?.props?.disabled ||
     !!element?.props?.accessibilityState?.disabled ||
-    !!element?.props?.accessibilityStates?.includes('disabled') ||
-    element?.props?.editable === false
+    !!element?.props?.accessibilityStates?.includes('disabled')
   );
 }
 

--- a/src/to-be-disabled.ts
+++ b/src/to-be-disabled.ts
@@ -23,7 +23,8 @@ function isElementDisabled(element: ReactTestInstance) {
   return (
     !!element?.props?.disabled ||
     !!element?.props?.accessibilityState?.disabled ||
-    !!element?.props?.accessibilityStates?.includes('disabled')
+    !!element?.props?.accessibilityStates?.includes('disabled') ||
+    element?.props?.editable === false
   );
 }
 

--- a/src/to-be-disabled.ts
+++ b/src/to-be-disabled.ts
@@ -18,10 +18,10 @@ const DISABLE_TYPES = [
 ];
 
 function isElementDisabled(element: ReactTestInstance) {
-  if (!DISABLE_TYPES.includes(getType(element))) return false;
   if (getType(element) === 'TextInput' && element?.props?.editable === false) {
     return true;
   }
+  if (!DISABLE_TYPES.includes(getType(element))) return false;
 
   return (
     !!element?.props?.disabled ||

--- a/src/to-be-disabled.ts
+++ b/src/to-be-disabled.ts
@@ -21,7 +21,10 @@ function isElementDisabled(element: ReactTestInstance) {
   if (getType(element) === 'TextInput' && element?.props?.editable === false) {
     return true;
   }
-  if (!DISABLE_TYPES.includes(getType(element))) return false;
+
+  if (!DISABLE_TYPES.includes(getType(element))) {
+    return false;
+  }
 
   return (
     !!element?.props?.disabled ||


### PR DESCRIPTION
<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
`toBeDisabled` and `toBeEnabled` matcher will now look at the `editable` prop from the `TextInput` component

**Why**:

<!-- Why are these changes necessary? -->
`TextInput` does not have a `disabled` props but a `editable` to enable or disable it. The only way to test if it is truly disabled is through `editable`

**How**:

<!-- How were these changes implemented? -->
Added a supplementary check in `isElementDisabled` function

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the [docs](https://github.com/testing-library/jest-native/README.md)
- [x] Typescript definitions updated (N/A)
- [x] Tests
- [x] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
