### PR TITLE
refactor: expose legacy extend-expect

### DIFF
--- a/legacy-extend-expect.d.ts
+++ b/legacy-extend-expect.d.ts
@@ -1,0 +1,30 @@
+import type { AccessibilityState, ImageStyle, StyleProp, TextStyle, ViewStyle } from 'react-native';
+import type { ReactTestInstance } from 'react-test-renderer';
+import type { AccessibilityValueMatcher } from './src/to-have-accessibility-value';
+
+export interface JestNativeMatchers<R> {
+  legacy_toBeDisabled(): R;
+  legacy_toBeEmptyElement(): R;
+  legacy_toBeEnabled(): R;
+  legacy_toBeOnTheScreen(): R;
+  legacy_toBeVisible(): R;
+  legacy_toContainElement(element: ReactTestInstance | null): R;
+  legacy_toHaveTextContent(text: string | RegExp, options?: { normalizeWhitespace: boolean }): R;
+  legacy_toHaveProp(attr: string, value?: unknown): R;
+  legacy_toHaveStyle(style: StyleProp<ViewStyle | TextStyle | ImageStyle>): R;
+  legacy_toHaveAccessibilityState(state: AccessibilityState): R;
+  legacy_toHaveAccessibilityValue(value: AccessibilityValueMatcher): R;
+}
+
+// Implicit Jest global `expect`.
+declare global {
+  namespace jest {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    interface Matchers<R, T = {}> extends JestNativeMatchers<R> {}
+  }
+}
+
+// Explicit `@jest/globals` `expect` matchers.
+declare module '@jest/expect' {
+  interface Matchers<R extends void | Promise<void>> extends JestNativeMatchers<R> {}
+}

--- a/legacy-extend-expect.js
+++ b/legacy-extend-expect.js
@@ -1,0 +1,1 @@
+require('./dist/legacy-extend-expect');

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   "files": [
     "dist",
     "extend-expect.js",
-    "extend-expect.d.ts"
+    "extend-expect.d.ts",
+    "legacy-extend-expect.js",
+    "legacy-extend-expect.d.ts"
   ],
   "keywords": [
     "testing",

--- a/src/__tests__/legacy-extend-expect.tsx
+++ b/src/__tests__/legacy-extend-expect.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import { render, screen } from '@testing-library/react-native';
+import '../legacy-extend-expect';
+
+test('legacy expect.extend() works correctly', () => {
+  render(
+    <View testID="view">
+      <Text>Hello</Text>
+    </View>,
+  );
+  expect(screen.getByTestId('view')).legacy_toBeOnTheScreen();
+  expect(screen.getByTestId('view')).legacy_toHaveTextContent('Hello');
+  expect(screen.getByTestId('view')).legacy_toBeVisible();
+  expect(screen.getByTestId('view')).legacy_toBeEnabled();
+  expect(screen.getByTestId('view')).not.legacy_toBeDisabled();
+});

--- a/src/legacy-extend-expect.ts
+++ b/src/legacy-extend-expect.ts
@@ -1,0 +1,24 @@
+import { toBeDisabled, toBeEnabled } from './to-be-disabled';
+import { toBeEmptyElement } from './to-be-empty-element';
+import { toBeOnTheScreen } from './to-be-on-the-screen';
+import { toBeVisible } from './to-be-visible';
+import { toContainElement } from './to-contain-element';
+import { toHaveAccessibilityState } from './to-have-accessibility-state';
+import { toHaveAccessibilityValue } from './to-have-accessibility-value';
+import { toHaveProp } from './to-have-prop';
+import { toHaveStyle } from './to-have-style';
+import { toHaveTextContent } from './to-have-text-content';
+
+expect.extend({
+  legacy_toBeDisabled: toBeDisabled,
+  legacy_toBeEnabled: toBeEnabled,
+  legacy_toBeEmptyElement: toBeEmptyElement,
+  legacy_toBeOnTheScreen: toBeOnTheScreen,
+  legacy_toBeVisible: toBeVisible,
+  legacy_toContainElement: toContainElement,
+  legacy_toHaveAccessibilityState: toHaveAccessibilityState,
+  legacy_toHaveAccessibilityValue: toHaveAccessibilityValue,
+  legacy_toHaveProp: toHaveProp,
+  legacy_toHaveStyle: toHaveStyle,
+  legacy_toHaveTextContent: toHaveTextContent,
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "noEmit": false,
     "outDir": "dist"
   },
-  "files": ["./extend-expect.d.ts"],
+  "files": ["./extend-expect.d.ts", "./legacy-extend-expect.d.ts"],
   "exclude": ["node_modules", "android", "ios"],
   "include": ["src/**/*", "setup-test.ts"]
 }


### PR DESCRIPTION
**What**:

This PR is exposing alternative `legacy_toXxx` matcher naming, in order to support ongoing migration of Jest Native matchers to RNTL, so that users can use both new RNTL matchers and legacy Jest Native matchers to gradually migrate their code. 

This PR is not doing advertising this change yet, as the RNTL migration is ongoing. I would add relevant documentation when RNTL matchers are read.

**Why**:

This is needed as migrated matchers are usually named the same as Jest Native matchers, so without this there would be a naming clash.

**How**:

Add `legacy-extend-expect` export, so which extends `expect` with `legacy_toXxx` matchers rather than typically `toXxx` naming. The original `extend-expect` remains still available, so existing users should not be affected.

**Checklist**:

- [x] Documentation added to the [docs](https://github.com/testing-library/jest-native/README.md) - N/A
- [x] Typescript definitions updated
- [x] Tests - N/A
- [x] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
