### PR TITLE
[docs] Updated correct links to Jest Matchers docs and migration guide in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 > [!CAUTION]
 > **This package is deprecated and is no longer actively maintained.**
 > 
-> We encourage you to migrate to React Native Testing Library, v12.4 or later, which includes modern [built-in Jest matchers](https://callstack.github.io/react-native-testing-library/docs/jest-matchers) based on the matchers for this repository.
+> We encourage you to migrate to React Native Testing Library, v12.4 or later, which includes modern [built-in Jest matchers](https://callstack.github.io/react-native-testing-library/docs/api/jest-matchers) based on the matchers for this repository.
 >
-> The migration process should be relatively straightforward, we have a [migration guide](https://callstack.github.io/react-native-testing-library/docs/migration-jest-native) available.
+> The migration process should be relatively straightforward, we have a [migration guide](https://callstack.github.io/react-native-testing-library/docs/migration/jest-matchers) available.
 
 
 <div align="center">


### PR DESCRIPTION

**What**:

 I have updated the correct links to Jest Matchers docs and migration guide 

**Why**:

 The existing links returns 404 page in RNTL 

**How**:

Updated the Readme file with correct links 

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the [docs](https://github.com/testing-library/jest-native/blob/main/README.md)
- [ ] Typescript definitions updated "(N/A)"
- [ ] Tests "(N/A)"
- [x] Ready to be merged 

<!-- feel free to add additional comments -->
